### PR TITLE
improve readback

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,7 +163,7 @@ fn debug_hook(net: &Net, book: &Book, hvmc_names: &HvmcNames, labels: &Labels, l
   println!(
     "{}{}\n---------------------------------------",
     if errors.is_empty() { "".to_string() } else { format!("Invalid readback: {:?}\n", errors) },
-    res_term.to_string(&book.def_names)
+    res_term.display(&book.def_names)
   );
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -102,7 +102,7 @@ fn main() {
           } else {
             format!("Invalid readback: {:?}\n", readback_errors)
           },
-          res_term.to_string(&def_names)
+          res_term.display(&def_names)
         );
 
         if args.stats {

--- a/src/term/display.rs
+++ b/src/term/display.rs
@@ -1,0 +1,204 @@
+use std::fmt::{self, Display};
+
+use crate::term::Name;
+
+use super::{Book, DefId, DefNames, Definition, MatchNum, Op, Pattern, Rule, Tag, Term};
+
+macro_rules! display {
+  ($($x:tt)*) => {
+    DisplayFn(move |f| write!(f, $($x)*))
+  };
+}
+
+impl Term {
+  fn display_app<'a>(&'a self, tag: &'a Tag, def_names: &'a DefNames) -> impl Display + 'a {
+    DisplayFn(move |f| match self {
+      Term::App { tag: tag2, fun, arg } if tag2 == tag => {
+        write!(f, "{} {}", fun.display_app(tag, def_names), arg.display(def_names))
+      }
+      _ => write!(f, "{}", self.display(def_names)),
+    })
+  }
+  pub fn display<'a>(&'a self, def_names: &'a DefNames) -> impl Display + 'a {
+    DisplayFn(move |f| match self {
+      Term::Lam { tag, nam, bod } => {
+        write!(
+          f,
+          "λ{}{} {}",
+          tag.display_padded(),
+          nam.clone().unwrap_or(Name::new("*")),
+          bod.display(def_names)
+        )
+      }
+      Term::Var { nam } => write!(f, "{nam}"),
+      Term::Chn { tag, nam, bod } => {
+        write!(f, "λ{}${} {}", tag.display_padded(), nam, bod.display(def_names))
+      }
+      Term::Lnk { nam } => write!(f, "${nam}"),
+      Term::Let { pat, val, nxt } => {
+        write!(f, "let {} = {}; {}", pat, val.display(def_names), nxt.display(def_names))
+      }
+      Term::Ref { def_id } => write!(f, "{}", def_names.name(def_id).unwrap()),
+      Term::App { tag, fun, arg } => {
+        write!(f, "({}{} {})", tag.display_padded(), fun.display_app(tag, def_names), arg.display(def_names))
+      }
+      Term::Match { scrutinee, arms } => {
+        write!(
+          f,
+          "match {} {{ {} }}",
+          scrutinee.display(def_names),
+          DisplayJoin(
+            || arms.iter().map(|(pat, term)| display!("{}: {}", pat, term.display(def_names))),
+            "; "
+          ),
+        )
+      }
+      Term::Dup { tag, fst, snd, val, nxt } => write!(
+        f,
+        "dup{} {} {} = {}; {}",
+        tag.display(),
+        fst.as_ref().map(|x| x.as_str()).unwrap_or("*"),
+        snd.as_ref().map(|x| x.as_str()).unwrap_or("*"),
+        val.display(def_names),
+        nxt.display(def_names)
+      ),
+      Term::Sup { tag, fst, snd } => {
+        write!(f, "{{{}{} {}}}", tag.display_padded(), fst.display(def_names), snd.display(def_names))
+      }
+      Term::Era => write!(f, "*"),
+      Term::Num { val } => write!(f, "{val}"),
+      Term::Opx { op, fst, snd } => {
+        write!(f, "({} {} {})", op, fst.display(def_names), snd.display(def_names))
+      }
+      Term::Tup { fst, snd } => write!(f, "({}, {})", fst.display(def_names), snd.display(def_names)),
+    })
+  }
+}
+
+impl Tag {
+  pub fn display_padded(&self) -> impl Display + '_ {
+    DisplayFn(move |f| match self {
+      Tag::Named(name) => write!(f, "#{name} "),
+      Tag::Numeric(num) => write!(f, "#{num} "),
+      Tag::Auto => Ok(()),
+      Tag::Static => Ok(()),
+    })
+  }
+  pub fn display(&self) -> impl Display + '_ {
+    DisplayFn(move |f| match self {
+      Tag::Named(name) => write!(f, "#{name}"),
+      Tag::Numeric(num) => write!(f, "#{num}"),
+      Tag::Auto => Ok(()),
+      Tag::Static => Ok(()),
+    })
+  }
+}
+
+impl Display for Pattern {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    match self {
+      Pattern::Var(None) => write!(f, "*"),
+      Pattern::Var(Some(nam)) => write!(f, "{nam}"),
+      Pattern::Ctr(nam, pats) => {
+        write!(f, "({}{})", nam, DisplayJoin(|| pats.iter().map(|p| display!(" {p}")), ""))
+      }
+      Pattern::Num(num) => write!(f, "{num}"),
+      Pattern::Tup(fst, snd) => write!(
+        f,
+        "({}, {})",
+        fst.as_ref().map(|s| &s.0[..]).unwrap_or("*"),
+        snd.as_ref().map(|s| &s.0[..]).unwrap_or("*"),
+      ),
+    }
+  }
+}
+
+impl Rule {
+  pub fn display<'a>(&'a self, def_id: &'a DefId, def_names: &'a DefNames) -> impl Display + 'a {
+    display!(
+      "({}{}) = {}",
+      def_names.name(def_id).unwrap(),
+      DisplayJoin(|| self.pats.iter().map(|x| display!(" {x}")), ""),
+      self.body.display(def_names)
+    )
+  }
+}
+
+impl Definition {
+  pub fn display<'a>(&'a self, def_names: &'a DefNames) -> impl Display + 'a {
+    DisplayJoin(|| self.rules.iter().map(|x| x.display(&self.def_id, def_names)), "\n")
+  }
+}
+
+impl fmt::Display for Book {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    write!(f, "{}", DisplayJoin(|| self.defs.values().map(|x| x.display(&self.def_names)), "\n\n"))
+  }
+}
+
+impl fmt::Display for MatchNum {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    match self {
+      MatchNum::Zero => write!(f, "0"),
+      MatchNum::Succ(_) => write!(f, "+"),
+    }
+  }
+}
+
+impl fmt::Display for Op {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    match self {
+      Op::ADD => write!(f, "+"),
+      Op::SUB => write!(f, "-"),
+      Op::MUL => write!(f, "*"),
+      Op::DIV => write!(f, "/"),
+      Op::MOD => write!(f, "%"),
+      Op::EQ => write!(f, "=="),
+      Op::NE => write!(f, "!="),
+      Op::LT => write!(f, "<"),
+      Op::GT => write!(f, ">"),
+      Op::LTE => write!(f, "<="),
+      Op::GTE => write!(f, ">="),
+      Op::AND => write!(f, "&"),
+      Op::OR => write!(f, "|"),
+      Op::XOR => write!(f, "^"),
+      Op::LSH => write!(f, "<<"),
+      Op::RSH => write!(f, ">>"),
+      Op::NOT => write!(f, "~"),
+    }
+  }
+}
+
+impl fmt::Display for Name {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    self.0.fmt(f)
+  }
+}
+
+struct DisplayFn<F: Fn(&mut fmt::Formatter) -> fmt::Result>(F);
+
+impl<F: Fn(&mut fmt::Formatter) -> fmt::Result> Display for DisplayFn<F> {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    self.0(f)
+  }
+}
+
+struct DisplayJoin<F, S>(F, S);
+
+impl<F, I, S> Display for DisplayJoin<F, S>
+where
+  F: (Fn() -> I),
+  I: Iterator,
+  I::Item: Display,
+  S: Display,
+{
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    for (i, x) in self.0().enumerate() {
+      if i != 0 {
+        self.1.fmt(f)?;
+      }
+      x.fmt(f)?;
+    }
+    Ok(())
+  }
+}

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -1,13 +1,10 @@
 use hvmc::run::Val;
 use indexmap::IndexMap;
-use itertools::Itertools;
 use shrinkwraprs::Shrinkwrap;
-use std::{
-  collections::{BTreeMap, HashMap},
-  fmt,
-};
+use std::collections::{BTreeMap, HashMap};
 
 pub mod check;
+pub mod display;
 pub mod load_book;
 pub mod net_to_term;
 pub mod parser;
@@ -273,87 +270,7 @@ impl DefNames {
   }
 }
 
-impl Tag {
-  pub fn to_string_padded(&self) -> String {
-    match self {
-      Tag::Named(name) => format!("#{name} "),
-      Tag::Numeric(num) => format!("#{num} "),
-      Tag::Auto => "".to_owned(),
-      Tag::Static => "".to_owned(),
-    }
-  }
-  pub fn to_string(&self) -> String {
-    match self {
-      Tag::Named(name) => format!("#{name}"),
-      Tag::Numeric(num) => format!("#{num}"),
-      Tag::Auto => "".to_owned(),
-      Tag::Static => "".to_owned(),
-    }
-  }
-}
-
 impl Term {
-  fn to_string_app(&self, tag: &Tag, def_names: &DefNames) -> String {
-    match self {
-      Term::App { tag: tag2, fun, arg } if tag2 == tag => {
-        format!("{} {}", fun.to_string_app(tag, def_names), arg.to_string(def_names))
-      }
-      _ => self.to_string(def_names),
-    }
-  }
-  pub fn to_string(&self, def_names: &DefNames) -> String {
-    match self {
-      Term::Lam { tag, nam, bod } => {
-        format!(
-          "λ{}{} {}",
-          tag.to_string_padded(),
-          nam.clone().unwrap_or(Name::new("*")),
-          bod.to_string(def_names)
-        )
-      }
-      Term::Var { nam } => format!("{nam}"),
-      Term::Chn { tag, nam, bod } => {
-        format!("λ{}${} {}", tag.to_string_padded(), nam, bod.to_string(def_names))
-      }
-      Term::Lnk { nam } => format!("${nam}"),
-      Term::Let { pat, val, nxt } => {
-        format!("let {} = {}; {}", pat, val.to_string(def_names), nxt.to_string(def_names))
-      }
-      Term::Ref { def_id } => format!("{}", def_names.name(def_id).unwrap()),
-      Term::App { tag, fun, arg } => {
-        format!(
-          "({}{} {})",
-          tag.to_string_padded(),
-          fun.to_string_app(tag, def_names),
-          arg.to_string(def_names)
-        )
-      }
-      Term::Match { scrutinee, arms } => {
-        let arms =
-          arms.iter().map(|(pat, term)| format!("{}: {}", pat, term.to_string(def_names))).join("; ");
-
-        format!("match {} {{ {} }}", scrutinee.to_string(def_names), arms,)
-      }
-      Term::Dup { tag, fst, snd, val, nxt } => format!(
-        "dup{} {} {} = {}; {}",
-        tag.to_string(),
-        fst.as_ref().map(|x| x.as_str()).unwrap_or("*"),
-        snd.as_ref().map(|x| x.as_str()).unwrap_or("*"),
-        val.to_string(def_names),
-        nxt.to_string(def_names)
-      ),
-      Term::Sup { tag, fst, snd } => {
-        format!("{{{}{} {}}}", tag.to_string_padded(), fst.to_string(def_names), snd.to_string(def_names))
-      }
-      Term::Era => "*".to_string(),
-      Term::Num { val } => format!("{val}"),
-      Term::Opx { op, fst, snd } => {
-        format!("({} {} {})", op, fst.to_string(def_names), snd.to_string(def_names))
-      }
-      Term::Tup { fst, snd } => format!("({}, {})", fst.to_string(def_names), snd.to_string(def_names)),
-    }
-  }
-
   /// Make a call term by folding args around a called function term with applications.
   pub fn call(called: Term, args: impl IntoIterator<Item = Term>) -> Self {
     args.into_iter().fold(called, |acc, arg| Term::App {
@@ -549,55 +466,19 @@ pub fn native_match(arms: Vec<(Pattern, Term)>) -> (Term, Term) {
   }
 }
 
-impl fmt::Display for Pattern {
-  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    match self {
-      Pattern::Var(None) => write!(f, "*"),
-      Pattern::Var(Some(nam)) => write!(f, "{nam}"),
-      Pattern::Ctr(nam, pats) => write!(f, "({}{})", nam, pats.iter().map(|p| format!(" {p}")).join("")),
-      Pattern::Num(num) => write!(f, "{num}"),
-      Pattern::Tup(fst, snd) => write!(
-        f,
-        "({}, {})",
-        fst.as_ref().map(|s| s.to_string()).unwrap_or("*".to_string()),
-        snd.as_ref().map(|s| s.to_string()).unwrap_or("*".to_string()),
-      ),
-    }
-  }
-}
-
 impl Rule {
-  pub fn to_string(&self, def_id: &DefId, def_names: &DefNames) -> String {
-    format!(
-      "({}{}) = {}",
-      def_names.name(def_id).unwrap(),
-      self.pats.iter().map(|x| format!(" {x}")).join(""),
-      self.body.to_string(def_names)
-    )
-  }
-
   pub fn arity(&self) -> usize {
     self.pats.len()
   }
 }
 
 impl Definition {
-  pub fn to_string(&self, def_names: &DefNames) -> String {
-    self.rules.iter().map(|x| x.to_string(&self.def_id, def_names)).join("\n")
-  }
-
   pub fn arity(&self) -> usize {
     self.rules[0].arity()
   }
 
   pub fn assert_no_pattern_matching_rules(&self) {
     assert!(self.rules.len() == 1, "Definition rules should have been removed in earlier pass");
-  }
-}
-
-impl fmt::Display for Book {
-  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    write!(f, "{}", self.defs.values().map(|x| x.to_string(&self.def_names)).join("\n\n"))
   }
 }
 
@@ -610,44 +491,5 @@ impl From<&Pattern> for Term {
       Pattern::Num(..) => todo!(),
       Pattern::Tup(..) => todo!(),
     }
-  }
-}
-
-impl fmt::Display for MatchNum {
-  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    match self {
-      MatchNum::Zero => write!(f, "0"),
-      MatchNum::Succ(_) => write!(f, "+"),
-    }
-  }
-}
-
-impl fmt::Display for Op {
-  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    match self {
-      Op::ADD => write!(f, "+"),
-      Op::SUB => write!(f, "-"),
-      Op::MUL => write!(f, "*"),
-      Op::DIV => write!(f, "/"),
-      Op::MOD => write!(f, "%"),
-      Op::EQ => write!(f, "=="),
-      Op::NE => write!(f, "!="),
-      Op::LT => write!(f, "<"),
-      Op::GT => write!(f, ">"),
-      Op::LTE => write!(f, "<="),
-      Op::GTE => write!(f, ">="),
-      Op::AND => write!(f, "&"),
-      Op::OR => write!(f, "|"),
-      Op::XOR => write!(f, "^"),
-      Op::LSH => write!(f, "<<"),
-      Op::RSH => write!(f, ">>"),
-      Op::NOT => write!(f, "~"),
-    }
-  }
-}
-
-impl fmt::Display for Name {
-  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    self.0.fmt(f)
   }
 }

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -14,7 +14,7 @@ pub mod parser;
 pub mod term_to_net;
 pub mod transform;
 
-pub use net_to_term::net_to_term_linear;
+pub use net_to_term::{net_to_term, ReadbackError};
 pub use term_to_net::{book_to_nets, term_to_compat_net};
 
 /// The representation of a program.

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -293,6 +293,14 @@ impl Tag {
 }
 
 impl Term {
+  fn to_string_app(&self, tag: &Tag, def_names: &DefNames) -> String {
+    match self {
+      Term::App { tag: tag2, fun, arg } if tag2 == tag => {
+        format!("{} {}", fun.to_string_app(tag, def_names), arg.to_string(def_names))
+      }
+      _ => self.to_string(def_names),
+    }
+  }
   pub fn to_string(&self, def_names: &DefNames) -> String {
     match self {
       Term::Lam { tag, nam, bod } => {
@@ -313,7 +321,12 @@ impl Term {
       }
       Term::Ref { def_id } => format!("{}", def_names.name(def_id).unwrap()),
       Term::App { tag, fun, arg } => {
-        format!("({}{} {})", tag.to_string_padded(), fun.to_string(def_names), arg.to_string(def_names))
+        format!(
+          "({}{} {})",
+          tag.to_string_padded(),
+          fun.to_string_app(tag, def_names),
+          arg.to_string(def_names)
+        )
       }
       Term::Match { scrutinee, arms } => {
         let arms =

--- a/src/term/net_to_term.rs
+++ b/src/term/net_to_term.rs
@@ -1,4 +1,4 @@
-use super::{term_to_net::Labels, var_id_to_name, Book, DefId, MatchNum, Name, Op, Term, Val};
+use super::{term_to_net::Labels, var_id_to_name, Book, DefId, MatchNum, Name, Op, Tag, Term, Val};
 use crate::{
   net::{INet, NodeId, NodeKind::*, Port, SlotId, ROOT},
   term::Pattern,
@@ -8,202 +8,214 @@ use indexmap::IndexSet;
 use std::collections::{HashMap, HashSet};
 
 // TODO: Display scopeless lambdas as such
-/// Converts an Interaction-INet to a Lambda Calculus term, resolvind Dups and Sups where possible.
-pub fn net_to_term_non_linear(net: &INet, book: &Book, labels: &Labels) -> (Term, bool) {
-  /// Reads a term recursively by starting at root node.
-  /// Returns the term and whether it's a valid readback.
-  fn reader(
-    net: &INet,
-    next: Port,
-    namegen: &mut NameGen,
-    dup_scope: &mut HashMap<u32, Vec<SlotId>>,
-    tup_scope: &mut Scope,
-    labels: &Labels,
-    book: &Book,
-  ) -> (Term, bool) {
+/// Converts an Interaction-INet to a Lambda Calculus term
+pub fn net_to_term(net: &INet, book: &Book, labels: &Labels, linear: bool) -> (Term, Vec<ReadbackError>) {
+  let mut reader = Reader {
+    net,
+    labels,
+    book,
+    dup_paths: if linear { None } else { Some(Default::default()) },
+    scope: Default::default(),
+    namegen: Default::default(),
+    seen: Default::default(),
+    errors: Default::default(),
+  };
+
+  let mut term = reader.read_term(net.enter_port(ROOT));
+
+  while let Some(node) = reader.scope.vec.pop() {
+    let val = reader.read_term(reader.net.enter_port(Port(node, 0)));
+    let fst = reader.namegen.decl_name(net, Port(node, 1));
+    let snd = reader.namegen.decl_name(net, Port(node, 2));
+    let mut free_vars = val.free_vars().into_keys().collect();
+
+    let tag = match reader.net.node(node).kind {
+      Tup => None,
+      Dup { lab } => Some(reader.labels.dup.to_tag(Some(lab))),
+      _ => unreachable!(),
+    };
+    let let_ctx = LetInsertion::Todo(tag, fst, snd, val);
+
+    match let_ctx.search_and_insert(&mut term, &mut free_vars).0 {
+      LetInsertion::Err(kind, fst, snd, val) => {
+        let result = term.insert_let(kind, fst, snd, val, &mut IndexSet::new());
+        debug_assert!(matches!(result, LetInsertion::Ok));
+      }
+      LetInsertion::Ok => {}
+      _ => unreachable!(),
+    }
+  }
+
+  (term, reader.errors)
+}
+
+#[derive(Debug)]
+pub enum ReadbackError {
+  InvalidNumericMatch,
+  ReachedRoot,
+  Cyclic,
+  InvalidBind,
+}
+
+struct Reader<'a> {
+  net: &'a INet,
+  labels: &'a Labels,
+  book: &'a Book,
+  dup_paths: Option<HashMap<u32, Vec<SlotId>>>,
+  scope: Scope,
+  namegen: NameGen,
+  seen: HashSet<Port>,
+  errors: Vec<ReadbackError>,
+}
+
+impl<'a> Reader<'a> {
+  fn read_term(&mut self, next: Port) -> Term {
+    if self.dup_paths.is_none() && !self.seen.insert(next) {
+      self.errors.push(ReadbackError::Cyclic);
+      return Term::Var { nam: Name::new("...") };
+    }
+
     let node = next.node();
 
-    match net.node(node).kind {
-      // If we're visiting a set...
+    let term = match self.net.node(node).kind {
       Era => {
         // Only the main port actually exists in an ERA, the auxes are just an artifact of this representation.
-        let valid = next.slot() == 0;
-        (Term::Era, valid)
+        debug_assert!(next.slot() == 0);
+        Term::Era
       }
       // If we're visiting a con node...
       Con { lab } => match next.slot() {
         // If we're visiting a port 0, then it is a lambda.
         0 => {
-          let nam = namegen.decl_name(net, Port(node, 1));
-          let prt = net.enter_port(Port(node, 2));
-          let (bod, valid) = reader(net, prt, namegen, dup_scope, tup_scope, labels, book);
-          (Term::Lam { tag: labels.con.to_tag(lab), nam, bod: Box::new(bod) }, valid)
+          let nam = self.namegen.decl_name(self.net, Port(node, 1));
+          let bod = self.read_term(self.net.enter_port(Port(node, 2)));
+          Term::Lam { tag: self.labels.con.to_tag(lab), nam, bod: Box::new(bod) }
         }
         // If we're visiting a port 1, then it is a variable.
-        1 => (Term::Var { nam: namegen.var_name(next) }, true),
+        1 => Term::Var { nam: self.namegen.var_name(next) },
         // If we're visiting a port 2, then it is an application.
         2 => {
-          let prt = net.enter_port(Port(node, 0));
-          let (fun, fun_valid) = reader(net, prt, namegen, dup_scope, tup_scope, labels, book);
-          let prt = net.enter_port(Port(node, 1));
-          let (arg, arg_valid) = reader(net, prt, namegen, dup_scope, tup_scope, labels, book);
-          let valid = fun_valid && arg_valid;
-          (Term::App { tag: labels.con.to_tag(lab), fun: Box::new(fun), arg: Box::new(arg) }, valid)
+          let fun = self.read_term(self.net.enter_port(Port(node, 0)));
+          let arg = self.read_term(self.net.enter_port(Port(node, 1)));
+          Term::App { tag: self.labels.con.to_tag(lab), fun: Box::new(fun), arg: Box::new(arg) }
         }
         _ => unreachable!(),
       },
       Mat => match next.slot() {
         2 => {
           // Read the matched expression
-          let cond_port = net.enter_port(Port(node, 0));
-          let (cond_term, cond_valid) = reader(net, cond_port, namegen, dup_scope, tup_scope, labels, book);
+          let scrutinee = self.read_term(self.net.enter_port(Port(node, 0)));
 
           // Read the pattern matching node
-          let sel_node = net.enter_port(Port(node, 1)).node();
+          let sel_node = self.net.enter_port(Port(node, 1)).node();
 
           // We expect the pattern matching node to be a CON
-          let sel_kind = net.node(sel_node).kind;
+          let sel_kind = self.net.node(sel_node).kind;
           if sel_kind != (Con { lab: None }) {
             // TODO: Is there any case where we expect a different node type here on readback?
-            return (Term::new_native_match(cond_term, Term::Era, None, Term::Era), false);
+            self.errors.push(ReadbackError::InvalidNumericMatch);
+            Term::new_native_match(scrutinee, Term::Era, None, Term::Era)
+          } else {
+            let zero_term = self.read_term(self.net.enter_port(Port(sel_node, 1)));
+            let succ_term = self.read_term(self.net.enter_port(Port(sel_node, 2)));
+
+            let Term::Lam { nam, bod, .. } = succ_term else { unreachable!() };
+
+            Term::new_native_match(scrutinee, zero_term, nam, *bod)
           }
-
-          let zero_port = net.enter_port(Port(sel_node, 1));
-          let (zero_term, zero_valid) = reader(net, zero_port, namegen, dup_scope, tup_scope, labels, book);
-          let succ_port = net.enter_port(Port(sel_node, 2));
-          let (succ_term, succ_valid) = reader(net, succ_port, namegen, dup_scope, tup_scope, labels, book);
-
-          let valid = cond_valid && zero_valid && succ_valid;
-
-          let Term::Lam { nam, bod, .. } = succ_term else { unreachable!() };
-
-          let term = Term::new_native_match(cond_term, zero_term, nam, *bod);
-          (term, valid)
         }
         _ => unreachable!(),
       },
       Ref { def_id } => {
-        if book.is_generated_def(def_id) {
-          let def = book.defs.get(&def_id).unwrap();
+        if self.book.is_generated_def(def_id) {
+          let def = self.book.defs.get(&def_id).unwrap();
           def.assert_no_pattern_matching_rules();
           let mut term = def.rules[0].body.clone();
-          term.fix_names(&mut namegen.id_counter, book);
+          term.fix_names(&mut self.namegen.id_counter, self.book);
 
-          (term, true)
+          term
         } else {
-          (Term::Ref { def_id }, true)
+          Term::Ref { def_id }
         }
       }
       // If we're visiting a fan node...
       Dup { lab } => match next.slot() {
         // If we're visiting a port 0, then it is a pair.
         0 => {
-          let stack = dup_scope.entry(lab).or_default();
-          if let Some(slot) = stack.pop() {
-            // Since we had a paired Dup in the path to this Sup,
-            // we "decay" the superposition according to the original direction we came from the Dup.
-            let chosen = net.enter_port(Port(node, slot));
-            let (val, valid) = reader(net, chosen, namegen, dup_scope, tup_scope, labels, book);
-            dup_scope.get_mut(&lab).unwrap().push(slot);
-            (val, valid)
+          if let Some(dup_paths) = &mut self.dup_paths {
+            let stack = dup_paths.entry(lab).or_default();
+            if let Some(slot) = stack.pop() {
+              // Since we had a paired Dup in the path to this Sup,
+              // we "decay" the superposition according to the original direction we came from the Dup.
+              let term = self.read_term(self.net.enter_port(Port(node, slot)));
+              self.dup_paths.as_mut().unwrap().get_mut(&lab).unwrap().push(slot);
+              Some(term)
+            } else {
+              None
+            }
           } else {
-            // If no Dup with same label in the path, we can't resolve the Sup, so keep it as a term.
-            let fst = net.enter_port(Port(node, 1));
-            let snd = net.enter_port(Port(node, 2));
-            let (fst, fst_valid) = reader(net, fst, namegen, dup_scope, tup_scope, labels, book);
-            let (snd, snd_valid) = reader(net, snd, namegen, dup_scope, tup_scope, labels, book);
-            let valid = fst_valid && snd_valid;
-            (Term::Sup { tag: labels.dup.to_tag(Some(lab)), fst: Box::new(fst), snd: Box::new(snd) }, valid)
+            None
           }
+          .unwrap_or_else(|| {
+            // If no Dup with same label in the path, we can't resolve the Sup, so keep it as a term.
+            let fst = self.read_term(self.net.enter_port(Port(node, 1)));
+            let snd = self.read_term(self.net.enter_port(Port(node, 2)));
+            Term::Sup { tag: self.labels.dup.to_tag(Some(lab)), fst: Box::new(fst), snd: Box::new(snd) }
+          })
         }
         // If we're visiting a port 1 or 2, then it is a variable.
         // Also, that means we found a dup, so we store it to read later.
         1 | 2 => {
-          let body = net.enter_port(Port(node, 0));
-          dup_scope.entry(lab).or_default().push(next.slot());
-          let (body, valid) = reader(net, body, namegen, dup_scope, tup_scope, labels, book);
-          dup_scope.entry(lab).or_default().pop().unwrap();
-          (body, valid)
+          if let Some(dup_paths) = &mut self.dup_paths {
+            dup_paths.entry(lab).or_default().push(next.slot());
+            let term = self.read_term(self.net.enter_port(Port(node, 0)));
+            self.dup_paths.as_mut().unwrap().entry(lab).or_default().pop().unwrap();
+            term
+          } else {
+            self.scope.insert(node);
+            Term::Var { nam: self.namegen.var_name(next) }
+          }
         }
         _ => unreachable!(),
       },
-      Num { val } => (Term::Num { val }, true),
+      Num { val } => Term::Num { val },
       Op2 { opr } => match next.slot() {
         2 => {
-          let op_port = net.enter_port(Port(node, 0));
-          let (fst, fst_valid) = reader(net, op_port, namegen, dup_scope, tup_scope, labels, book);
-          let arg_port = net.enter_port(Port(node, 1));
-          let (snd, snd_valid) = reader(net, arg_port, namegen, dup_scope, tup_scope, labels, book);
-          let valid = fst_valid && snd_valid;
+          let fst = self.read_term(self.net.enter_port(Port(node, 0)));
+          let snd = self.read_term(self.net.enter_port(Port(node, 1)));
 
-          let term =
-            Term::Opx { op: Op::from_hvmc_label(opr).unwrap(), fst: Box::new(fst), snd: Box::new(snd) };
-
-          (term, valid)
+          Term::Opx { op: Op::from_hvmc_label(opr).unwrap(), fst: Box::new(fst), snd: Box::new(snd) }
         }
         _ => unreachable!(),
       },
-      Rot => (Term::Era, false),
+      Rot => {
+        self.errors.push(ReadbackError::ReachedRoot);
+        Term::Era
+      }
       Tup => match next.slot() {
         // If we're visiting a port 0, then it is a Tup.
         0 => {
-          let fst_port = net.enter_port(Port(node, 1));
-          let (fst, fst_valid) = reader(net, fst_port, namegen, dup_scope, tup_scope, labels, book);
-          let snd_port = net.enter_port(Port(node, 2));
-          let (snd, snd_valid) = reader(net, snd_port, namegen, dup_scope, tup_scope, labels, book);
-          let valid = fst_valid && snd_valid;
-          (Term::Tup { fst: Box::new(fst), snd: Box::new(snd) }, valid)
+          let fst = self.read_term(self.net.enter_port(Port(node, 1)));
+          let snd = self.read_term(self.net.enter_port(Port(node, 2)));
+          Term::Tup { fst: Box::new(fst), snd: Box::new(snd) }
         }
         // If we're visiting a port 1 or 2, then it is a variable.
-        // Also, that means we found a let, so we store it to read later.
         1 | 2 => {
-          tup_scope.insert(node);
-          (Term::Var { nam: namegen.var_name(next) }, true)
+          self.scope.insert(node);
+          Term::Var { nam: self.namegen.var_name(next) }
         }
         _ => unreachable!(),
       },
-    }
+    };
+
+    term
   }
-  // A hashmap linking ports to binder names. Those ports have names:
-  // Port 1 of a con node (λ), ports 1 and 2 of a fan node (let).
-  let mut namegen = NameGen::default();
-
-  let mut dup_scope = HashMap::new();
-  let mut tup_scope = Scope::default();
-
-  // Reads the main term from the net
-  let (mut main, mut valid) =
-    reader(net, net.enter_port(ROOT), &mut namegen, &mut dup_scope, &mut tup_scope, labels, book);
-
-  // Read all the let bodies.
-  while let Some(tup) = tup_scope.vec.pop() {
-    let val = net.enter_port(Port(tup, 0));
-    let (val, val_valid) = reader(net, val, &mut namegen, &mut dup_scope, &mut tup_scope, labels, book);
-    let fst = namegen.decl_name(net, Port(tup, 1));
-    let snd = namegen.decl_name(net, Port(tup, 2));
-
-    let mut free_vars = val.free_vars().into_keys().collect();
-
-    let let_ctx = LetInsertion::Todo(fst, snd, val);
-
-    match let_ctx.search_and_insert(&mut main, &mut free_vars).0 {
-      LetInsertion::Err(fst, snd, val) => {
-        main = Term::Let { pat: Pattern::Tup(fst, snd), val: Box::new(val), nxt: Box::new(main) }
-      }
-      LetInsertion::Ok => {}
-      _ => unreachable!(),
-    }
-
-    valid = valid && val_valid;
-  }
-
-  (main, valid)
 }
 
 enum LetInsertion {
   Ok,
-  Err(Option<Name>, Option<Name>, Term),
-  Todo(Option<Name>, Option<Name>, Term),
+  Err(Option<Tag>, Option<Name>, Option<Name>, Term),
+  Todo(Option<Tag>, Option<Name>, Option<Name>, Term),
 }
 
 impl LetInsertion {
@@ -211,7 +223,7 @@ impl LetInsertion {
   /// and where the its vars are used
   fn search_and_insert(self, term: &mut Term, free_vars: &mut IndexSet<Name>) -> (LetInsertion, bool) {
     match term.resolve_let_scope(self, free_vars) {
-      (Self::Todo(fst, snd, val), true) => (term.insert_let(fst, snd, val, free_vars), true),
+      (Self::Todo(tag, fst, snd, val), true) => (term.insert_let(tag, fst, snd, val, free_vars), true),
       (ctx, uses) => (ctx, uses),
     }
   }
@@ -237,7 +249,9 @@ impl LetInsertion {
       var_uses.into_iter().enumerate().filter_map(|(index, is_used)| is_used.then_some(index)).collect();
 
     match (used_in_terms.len(), ctx) {
-      (1, Self::Todo(fst, snd, val)) => (terms[used_in_terms[0]].insert_let(fst, snd, val, free_vars), true),
+      (1, Self::Todo(tag, fst, snd, val)) => {
+        (terms[used_in_terms[0]].insert_let(tag, fst, snd, val, free_vars), true)
+      }
       (0, ctx) => (ctx, false),
       (_, ctx) => (ctx, true),
     }
@@ -247,6 +261,7 @@ impl LetInsertion {
 impl Term {
   fn insert_let(
     &mut self,
+    tag: Option<Tag>,
     fst: Option<Name>,
     snd: Option<Name>,
     val: Term,
@@ -256,11 +271,15 @@ impl Term {
     if free_vars.is_empty() {
       let nxt = Box::new(std::mem::replace(self, Term::Era));
 
-      *self = Term::Let { pat: Pattern::Tup(fst, snd), val: Box::new(val), nxt };
+      *self = match tag {
+        None => Term::Let { pat: Pattern::Tup(fst, snd), val: Box::new(val), nxt },
+        Some(tag) => Term::Dup { tag, fst, snd, val: Box::new(val), nxt },
+      };
+
       LetInsertion::Ok
     } else {
       // Otherwise, return a failed attempt, that will pass through to the first call to `search and insert`
-      LetInsertion::Err(fst, snd, val)
+      LetInsertion::Err(tag, fst, snd, val)
     }
   }
 
@@ -304,11 +323,11 @@ impl Term {
       }
 
       Term::Var { nam } => {
-        if let LetInsertion::Todo(fst, snd, val) = ctx {
-          let is_fst = fst.as_ref().map_or(false, |fst| fst == nam);
-          let is_snd = snd.as_ref().map_or(false, |snd| snd == nam);
+        if let LetInsertion::Todo(tag, fst, snd, val) = ctx {
+          let is_fst = fst.as_ref().is_some_and(|fst| fst == nam);
+          let is_snd = snd.as_ref().is_some_and(|snd| snd == nam);
 
-          (LetInsertion::Todo(fst, snd, val), is_fst || is_snd)
+          (LetInsertion::Todo(tag, fst, snd, val), is_fst || is_snd)
         } else {
           (ctx, false)
         }
@@ -324,211 +343,6 @@ impl Term {
       Term::Lnk { .. } | Term::Num { .. } | Term::Ref { .. } | Term::Era => (ctx, false),
     }
   }
-}
-
-/// Converts an Interaction-INet to an Interaction Calculus term.
-pub fn net_to_term_linear(net: &INet, book: &Book, labels: &Labels) -> (Term, bool) {
-  /// Reads a term recursively by starting at root node.
-  /// Returns the term and whether it's a valid readback.
-  fn reader(
-    net: &INet,
-    next: Port,
-    namegen: &mut NameGen,
-    dup_scope: &mut Scope,
-    tup_scope: &mut Scope,
-    seen: &mut HashSet<Port>,
-    labels: &Labels,
-    book: &Book,
-  ) -> (Term, bool) {
-    if seen.contains(&next) {
-      return (Term::Var { nam: Name::new("...") }, false);
-    }
-    seen.insert(next);
-
-    let node = next.node();
-
-    match net.node(node).kind {
-      // If we're visiting a set...
-      Era => {
-        // Only the main port actually exists in an ERA, the auxes are just an artifact of this representation.
-        let valid = next.slot() == 0;
-        (Term::Era, valid)
-      }
-      // If we're visiting a con node...
-      Con { lab } => match next.slot() {
-        // If we're visiting a port 0, then it is a lambda.
-        0 => {
-          seen.insert(Port(node, 2));
-          let nam = namegen.decl_name(net, Port(node, 1));
-          let prt = net.enter_port(Port(node, 2));
-          let (bod, valid) = reader(net, prt, namegen, dup_scope, tup_scope, seen, labels, book);
-          (Term::Lam { tag: labels.con.to_tag(lab), nam, bod: Box::new(bod) }, valid)
-        }
-        // If we're visiting a port 1, then it is a variable.
-        1 => (Term::Var { nam: namegen.var_name(next) }, true),
-        // If we're visiting a port 2, then it is an application.
-        2 => {
-          seen.insert(Port(node, 0));
-          seen.insert(Port(node, 1));
-          let prt = net.enter_port(Port(node, 0));
-          let (fun, fun_valid) = reader(net, prt, namegen, dup_scope, tup_scope, seen, labels, book);
-          let prt = net.enter_port(Port(node, 1));
-          let (arg, arg_valid) = reader(net, prt, namegen, dup_scope, tup_scope, seen, labels, book);
-          let valid = fun_valid && arg_valid;
-          (Term::App { tag: labels.con.to_tag(lab), fun: Box::new(fun), arg: Box::new(arg) }, valid)
-        }
-        _ => unreachable!(),
-      },
-      Mat => match next.slot() {
-        2 => {
-          // Read the matched expression
-          seen.insert(Port(node, 0));
-          seen.insert(Port(node, 1));
-          let cond_port = net.enter_port(Port(node, 0));
-          let (cond_term, cond_valid) =
-            reader(net, cond_port, namegen, dup_scope, tup_scope, seen, labels, book);
-
-          // Read the pattern matching node
-          let sel_node = net.enter_port(Port(node, 1)).node();
-          seen.insert(Port(sel_node, 0));
-          seen.insert(Port(sel_node, 1));
-          seen.insert(Port(sel_node, 2));
-
-          // We expect the pattern matching node to be a CON
-          let sel_kind = net.node(sel_node).kind;
-          if sel_kind != (Con { lab: None }) {
-            // TODO: Is there any case where we expect a different node type here on readback?
-            return (Term::new_native_match(cond_term, Term::Era, None, Term::Era), false);
-          }
-
-          let zero_port = net.enter_port(Port(sel_node, 1));
-          let (zero_term, zero_valid) =
-            reader(net, zero_port, namegen, dup_scope, tup_scope, seen, labels, book);
-          let succ_port = net.enter_port(Port(sel_node, 2));
-          let (succ_term, succ_valid) =
-            reader(net, succ_port, namegen, dup_scope, tup_scope, seen, labels, book);
-
-          let valid = cond_valid && zero_valid && succ_valid;
-
-          let Term::Lam { nam, bod, .. } = succ_term else { unreachable!() };
-
-          let term = Term::new_native_match(cond_term, zero_term, nam, *bod);
-          (term, valid)
-        }
-        _ => unreachable!(),
-      },
-      Ref { def_id } => {
-        if book.is_generated_def(def_id) {
-          let def = book.defs.get(&def_id).unwrap();
-          def.assert_no_pattern_matching_rules();
-          let mut term = def.rules[0].body.clone();
-          term.fix_names(&mut namegen.id_counter, book);
-
-          (term, true)
-        } else {
-          (Term::Ref { def_id }, true)
-        }
-      }
-      // If we're visiting a fan node...
-      Dup { lab } => match next.slot() {
-        // If we're visiting a port 0, then it is a pair.
-        0 => {
-          seen.insert(Port(node, 1));
-          seen.insert(Port(node, 2));
-          let fst_port = net.enter_port(Port(node, 1));
-          let (fst, fst_valid) = reader(net, fst_port, namegen, dup_scope, tup_scope, seen, labels, book);
-          let snd_port = net.enter_port(Port(node, 2));
-          let (snd, snd_valid) = reader(net, snd_port, namegen, dup_scope, tup_scope, seen, labels, book);
-          let valid = fst_valid && snd_valid;
-          (Term::Sup { tag: labels.dup.to_tag(Some(lab)), fst: Box::new(fst), snd: Box::new(snd) }, valid)
-        }
-        // If we're visiting a port 1 or 2, then it is a variable.
-        // Also, that means we found a dup, so we store it to read later.
-        1 | 2 => {
-          dup_scope.insert(node);
-          (Term::Var { nam: namegen.var_name(next) }, true)
-        }
-        _ => unreachable!(),
-      },
-      Num { val } => (Term::Num { val }, true),
-      Op2 { .. } => todo!(),
-      // If we're revisiting the root node something went wrong with this net
-      Rot => (Term::Era, false),
-      Tup => match next.slot() {
-        // If we're visiting a port 0, then it is a Tup.
-        0 => {
-          seen.insert(Port(node, 1));
-          seen.insert(Port(node, 2));
-          let fst_port = net.enter_port(Port(node, 1));
-          let (fst, fst_valid) = reader(net, fst_port, namegen, dup_scope, tup_scope, seen, labels, book);
-          let snd_port = net.enter_port(Port(node, 2));
-          let (snd, snd_valid) = reader(net, snd_port, namegen, dup_scope, tup_scope, seen, labels, book);
-          let valid = fst_valid && snd_valid;
-          (Term::Tup { fst: Box::new(fst), snd: Box::new(snd) }, valid)
-        }
-        // If we're visiting a port 1 or 2, then it is a variable.
-        // Also, that means we found a let, so we store it to read later.
-        1 | 2 => {
-          tup_scope.insert(node);
-          (Term::Var { nam: namegen.var_name(next) }, true)
-        }
-        _ => unreachable!(),
-      },
-    }
-  }
-
-  // A hashmap linking ports to binder names. Those ports have names:
-  // Port 1 of a con node (λ), ports 1 and 2 of a fan node (let).
-  let mut namegen = NameGen::default();
-
-  // Dup aren't scoped. We find them when we read one of the variables
-  // introduced by them. Thus, we must store the dups we find to read later.
-  // We have a vec for .pop(). and a set to avoid storing duplicates.
-  let mut dup_scope = Scope::default();
-  let mut tup_scope = Scope::default();
-  let mut seen = HashSet::new();
-
-  // Reads the main term from the net
-  let (mut main, mut valid) =
-    reader(net, net.enter_port(ROOT), &mut namegen, &mut dup_scope, &mut tup_scope, &mut seen, labels, book);
-
-  // Read all the dup bodies.
-  while let Some(dup) = dup_scope.vec.pop() {
-    seen.insert(Port(dup, 0));
-    let val = net.enter_port(Port(dup, 0));
-    let (val, val_valid) =
-      reader(net, val, &mut namegen, &mut dup_scope, &mut tup_scope, &mut seen, labels, book);
-    let Dup { lab } = net.node(dup).kind else { unreachable!() };
-    let fst = namegen.decl_name(net, Port(dup, 1));
-    let snd = namegen.decl_name(net, Port(dup, 2));
-    main = Term::Dup { tag: labels.dup.to_tag(Some(lab)), fst, snd, val: Box::new(val), nxt: Box::new(main) };
-    valid = valid && val_valid;
-  }
-
-  // Read all the let bodies.
-  while let Some(tup) = tup_scope.vec.pop() {
-    seen.insert(Port(tup, 0));
-    let val = net.enter_port(Port(tup, 0));
-    let (val, val_valid) =
-      reader(net, val, &mut namegen, &mut dup_scope, &mut tup_scope, &mut seen, labels, book);
-    let fst = namegen.decl_name(net, Port(tup, 1));
-    let snd = namegen.decl_name(net, Port(tup, 2));
-    main = Term::Let { pat: Pattern::Tup(fst, snd), val: Box::new(val), nxt: Box::new(main) };
-    valid = valid && val_valid;
-  }
-
-  // Check if the readback didn't leave any unread nodes (for example reading var from a lam but never reading the lam itself)
-  for &decl_port in namegen.var_port_to_id.keys() {
-    for check_slot in 0 .. 3 {
-      let check_port = Port(decl_port.node(), check_slot);
-      let other_node = net.enter_port(check_port).node();
-      if !seen.contains(&check_port) && net.node(other_node).kind != Era {
-        valid = false;
-      }
-    }
-  }
-
-  (main, valid)
 }
 
 #[derive(Default)]

--- a/tests/golden_tests.rs
+++ b/tests/golden_tests.rs
@@ -4,7 +4,7 @@ use hvml::{
   net::{hvmc_to_net::hvmc_to_net, net_to_hvmc::net_to_hvmc},
   run_book,
   term::{
-    net_to_term::net_to_term_non_linear,
+    net_to_term::net_to_term,
     parser::{parse_definition_book, parse_term},
     term_to_compat_net, Book, DefId, Term,
   },
@@ -104,11 +104,11 @@ fn run_single_files() {
   run_golden_test_dir(function_name!(), &|code| {
     let book = do_parse_book(code)?;
     // 1 million nodes for the test runtime. Smaller doesn't seem to make it any faster
-    let (res, def_names, info) = run_book(book, 1 << 20, true, false)?;
-    let res = if info.valid_readback {
+    let (res, def_names, info) = run_book(book, 1 << 20, true, false, false)?;
+    let res = if info.readback_errors.is_empty() {
       res.to_string(&def_names)
     } else {
-      format!("Invalid readback\n{}", res.to_string(&def_names))
+      format!("Invalid readback: {:?}\n{}", info.readback_errors, res.to_string(&def_names))
     };
     Ok(res)
   })
@@ -120,11 +120,11 @@ fn readback_lnet() {
     let net = do_parse_net(code)?;
     let book = Book::default();
     let compat_net = hvmc_to_net(&net, &DefId::from_internal);
-    let (term, valid) = net_to_term_non_linear(&compat_net, &book, &Default::default());
-    if valid {
+    let (term, errors) = net_to_term(&compat_net, &book, &Default::default(), false);
+    if errors.is_empty() {
       Ok(term.to_string(&book.def_names))
     } else {
-      Ok(format!("Invalid readback:\n{}", term.to_string(&book.def_names)))
+      Ok(format!("Invalid readback: {:?}\n{}", errors, term.to_string(&book.def_names)))
     }
   })
 }

--- a/tests/golden_tests.rs
+++ b/tests/golden_tests.rs
@@ -106,9 +106,9 @@ fn run_single_files() {
     // 1 million nodes for the test runtime. Smaller doesn't seem to make it any faster
     let (res, def_names, info) = run_book(book, 1 << 20, true, false, false)?;
     let res = if info.readback_errors.is_empty() {
-      res.to_string(&def_names)
+      res.display(&def_names).to_string()
     } else {
-      format!("Invalid readback: {:?}\n{}", info.readback_errors, res.to_string(&def_names))
+      format!("Invalid readback: {:?}\n{}", info.readback_errors, res.display(&def_names))
     };
     Ok(res)
   })
@@ -122,9 +122,9 @@ fn readback_lnet() {
     let compat_net = hvmc_to_net(&net, &DefId::from_internal);
     let (term, errors) = net_to_term(&compat_net, &book, &Default::default(), false);
     if errors.is_empty() {
-      Ok(term.to_string(&book.def_names))
+      Ok(term.display(&book.def_names).to_string())
     } else {
-      Ok(format!("Invalid readback: {:?}\n{}", errors, term.to_string(&book.def_names)))
+      Ok(format!("Invalid readback: {:?}\n{}", errors, term.display(&book.def_names)))
     }
   })
 }

--- a/tests/snapshots/encode_pattern_match__bool.hvm.snap
+++ b/tests/snapshots/encode_pattern_match__bool.hvm.snap
@@ -2,15 +2,15 @@
 source: tests/golden_tests.rs
 input_file: tests/golden_tests/encode_pattern_match/bool.hvm
 ---
-(not) = λx ((x not$Ptrue) not$Pfalse)
+(not) = λx (x not$Ptrue not$Pfalse)
 
-(and) = λx ((x and$Ptrue) and$Pfalse)
+(and) = λx (x and$Ptrue and$Pfalse)
 
-(and2) = λx ((x and2$Ptrue) and2$Pfalse)
+(and2) = λx (x and2$Ptrue and2$Pfalse)
 
-(and3) = λx ((x and3$Ptrue) and3$Pfalse)
+(and3) = λx (x and3$Ptrue and3$Pfalse)
 
-(and4) = λx ((x and4$Ptrue) and4$Pfalse)
+(and4) = λx (x and4$Ptrue and4$Pfalse)
 
 (true) = λtrue λfalse true
 
@@ -36,13 +36,13 @@ input_file: tests/golden_tests/encode_pattern_match/bool.hvm
 
 (and$Ptrue$Pfalse) = and$R2
 
-(and$Ptrue) = λx ((x and$Ptrue$Ptrue) and$Ptrue$Pfalse)
+(and$Ptrue) = λx (x and$Ptrue$Ptrue and$Ptrue$Pfalse)
 
 (and$Pfalse$Ptrue) = and$R1
 
 (and$Pfalse$Pfalse) = and$R0
 
-(and$Pfalse) = λx ((x and$Pfalse$Ptrue) and$Pfalse$Pfalse)
+(and$Pfalse) = λx (x and$Pfalse$Ptrue and$Pfalse$Pfalse)
 
 (and2$R0) = λb b
 
@@ -58,9 +58,9 @@ input_file: tests/golden_tests/encode_pattern_match/bool.hvm
 
 (and3$Ptrue$Ptrue) = and3$R0
 
-(and3$Ptrue$Pfalse) = ((and3$R1 true) false)
+(and3$Ptrue$Pfalse) = (and3$R1 true false)
 
-(and3$Ptrue) = λx ((x and3$Ptrue$Ptrue) and3$Ptrue$Pfalse)
+(and3$Ptrue) = λx (x and3$Ptrue$Ptrue and3$Ptrue$Pfalse)
 
 (and3$Pfalse) = (and3$R1 false)
 
@@ -70,10 +70,10 @@ input_file: tests/golden_tests/encode_pattern_match/bool.hvm
 
 (and4$R2) = λa λb true
 
-(and4$Ptrue$Ptrue) = ((and4$R2 true) true)
+(and4$Ptrue$Ptrue) = (and4$R2 true true)
 
 (and4$Ptrue$Pfalse) = (and4$R1 true)
 
-(and4$Ptrue) = λx ((x and4$Ptrue$Ptrue) and4$Ptrue$Pfalse)
+(and4$Ptrue) = λx (x and4$Ptrue$Ptrue and4$Ptrue$Pfalse)
 
 (and4$Pfalse) = and4$R0

--- a/tests/snapshots/encode_pattern_match__common.hvm.snap
+++ b/tests/snapshots/encode_pattern_match__common.hvm.snap
@@ -24,7 +24,7 @@ input_file: tests/golden_tests/encode_pattern_match/common.hvm
 
 (Green) = λRed λYellow λGreen Green
 
-(Cons) = λx λxs λCons λNil ((Cons x) xs)
+(Cons) = λx λxs λCons λNil (Cons x xs)
 
 (Nil) = λCons λNil Nil
 

--- a/tests/snapshots/encode_pattern_match__expr.hvm.snap
+++ b/tests/snapshots/encode_pattern_match__expr.hvm.snap
@@ -6,19 +6,19 @@ input_file: tests/golden_tests/encode_pattern_match/expr.hvm
 
 (Num) = λval λVar λNum λApp λFun λIf λLet λDup λTup λOp2 (Num val)
 
-(App) = λfun λarg λVar λNum λApp λFun λIf λLet λDup λTup λOp2 ((App fun) arg)
+(App) = λfun λarg λVar λNum λApp λFun λIf λLet λDup λTup λOp2 (App fun arg)
 
-(Fun) = λname λbody λVar λNum λApp λFun λIf λLet λDup λTup λOp2 ((Fun name) body)
+(Fun) = λname λbody λVar λNum λApp λFun λIf λLet λDup λTup λOp2 (Fun name body)
 
-(If) = λcond λthen λelse λVar λNum λApp λFun λIf λLet λDup λTup λOp2 (((If cond) then) else)
+(If) = λcond λthen λelse λVar λNum λApp λFun λIf λLet λDup λTup λOp2 (If cond then else)
 
-(Let) = λbind λval λnext λVar λNum λApp λFun λIf λLet λDup λTup λOp2 (((Let bind) val) next)
+(Let) = λbind λval λnext λVar λNum λApp λFun λIf λLet λDup λTup λOp2 (Let bind val next)
 
-(Dup) = λfst λsnd λval λnext λVar λNum λApp λFun λIf λLet λDup λTup λOp2 ((((Dup fst) snd) val) next)
+(Dup) = λfst λsnd λval λnext λVar λNum λApp λFun λIf λLet λDup λTup λOp2 (Dup fst snd val next)
 
-(Tup) = λfst λsnd λVar λNum λApp λFun λIf λLet λDup λTup λOp2 ((Tup fst) snd)
+(Tup) = λfst λsnd λVar λNum λApp λFun λIf λLet λDup λTup λOp2 (Tup fst snd)
 
-(Op2) = λop λfst λsnd λVar λNum λApp λFun λIf λLet λDup λTup λOp2 (((Op2 op) fst) snd)
+(Op2) = λop λfst λsnd λVar λNum λApp λFun λIf λLet λDup λTup λOp2 (Op2 op fst snd)
 
 (Add) = λAdd λSub λMul λDiv Add
 

--- a/tests/snapshots/encode_pattern_match__list_merge_sort.hvm.snap
+++ b/tests/snapshots/encode_pattern_match__list_merge_sort.hvm.snap
@@ -2,13 +2,13 @@
 source: tests/golden_tests.rs
 input_file: tests/golden_tests/encode_pattern_match/list_merge_sort.hvm
 ---
-(If) = λx ((x If$PTrue) If$PFalse)
+(If) = λx (x If$PTrue If$PFalse)
 
-(Pure) = λx ((Cons x) Nil)
+(Pure) = λx (Cons x Nil)
 
-(Map) = λx ((x Map$PCons) Map$PNil)
+(Map) = λx (x Map$PCons Map$PNil)
 
-(MergeSort) = λcmp λxs ((Unpack cmp) ((Map xs) Pure))
+(MergeSort) = λcmp λxs (Unpack cmp (Map xs Pure))
 
 (Unpack) = λx (Unpack$P x)
 
@@ -20,7 +20,7 @@ input_file: tests/golden_tests/encode_pattern_match/list_merge_sort.hvm
 
 (False) = λTrue λFalse False
 
-(Cons) = λhead λtail λCons λNil ((Cons head) tail)
+(Cons) = λhead λtail λCons λNil (Cons head tail)
 
 (Nil) = λCons λNil Nil
 
@@ -38,70 +38,70 @@ input_file: tests/golden_tests/encode_pattern_match/list_merge_sort.hvm
 
 (Map$R0) = λf Nil
 
-(Map$R1) = λh λt λf ((Cons (f h)) ((Map t) f))
+(Map$R1) = λh λt λf (Cons (f h) (Map t f))
 
-(Map$PCons) = λy0 λy1 ((Map$R1 y0) y1)
+(Map$PCons) = λy0 λy1 (Map$R1 y0 y1)
 
 (Map$PNil) = Map$R0
 
 (Unpack$R0) = λcmp Nil
 
-(Unpack$R1) = λcmp λh λx$0 (((Unpack$F0 cmp) h) x$0)
+(Unpack$R1) = λcmp λh λx$0 (Unpack$F0 cmp h x$0)
 
-(Unpack$R2) = λcmp λxs ((Unpack cmp) ((MergePair cmp) xs))
+(Unpack$R2) = λcmp λxs (Unpack cmp (MergePair cmp xs))
 
-(Unpack$P$PCons) = λy0 λy1 λx0 (((Unpack$R1 x0) y0) y1)
+(Unpack$P$PCons) = λy0 λy1 λx0 (Unpack$R1 x0 y0 y1)
 
 (Unpack$P$PNil) = λx0 (Unpack$R0 x0)
 
-(Unpack$P) = λy0 λx (((x Unpack$P$PCons) Unpack$P$PNil) y0)
+(Unpack$P) = λy0 λx (x Unpack$P$PCons Unpack$P$PNil y0)
 
-(MergePair$R0) = λcmp λh1 λx$0 (((MergePair$F0 cmp) h1) x$0)
+(MergePair$R0) = λcmp λh1 λx$0 (MergePair$F0 cmp h1 x$0)
 
 (MergePair$R1) = λcmp λxs xs
 
-(MergePair$P$PCons) = λy0 λy1 λx0 (((MergePair$R0 x0) y0) y1)
+(MergePair$P$PCons) = λy0 λy1 λx0 (MergePair$R0 x0 y0 y1)
 
-(MergePair$P$PNil) = λx0 ((MergePair$R1 x0) Nil)
+(MergePair$P$PNil) = λx0 (MergePair$R1 x0 Nil)
 
-(MergePair$P) = λy0 λx (((x MergePair$P$PCons) MergePair$P$PNil) y0)
+(MergePair$P) = λy0 λx (x MergePair$P$PCons MergePair$P$PNil y0)
 
 (Merge$R0) = λcmp λys ys
 
 (Merge$R1) = λcmp λxs xs
 
-(Merge$R2) = λcmp λxh λxt λyh λyt (((If ((cmp xh) yh)) let ys = ((Cons yh) yt); ((Cons xh) (((Merge cmp) xt) ys))) let xs = ((Cons xh) xt); ((Cons yh) (((Merge cmp) xs) yt)))
+(Merge$R2) = λcmp λxh λxt λyh λyt (If (cmp xh yh) let ys = (Cons yh yt); (Cons xh (Merge cmp xt ys)) let xs = (Cons xh xt); (Cons yh (Merge cmp xs yt)))
 
-(Merge$P$PCons$PCons) = λy0 λy1 λx0 λx1 λx2 (((((Merge$R2 x0) x1) x2) y0) y1)
+(Merge$P$PCons$PCons) = λy0 λy1 λx0 λx1 λx2 (Merge$R2 x0 x1 x2 y0 y1)
 
-(Merge$P$PCons$PNil) = λx0 λx1 λx2 ((Merge$R1 x0) ((Cons x1) x2))
+(Merge$P$PCons$PNil) = λx0 λx1 λx2 (Merge$R1 x0 (Cons x1 x2))
 
-(Merge$P$PCons) = λy0 λy1 λx0 λx (((((x Merge$P$PCons$PCons) Merge$P$PCons$PNil) x0) y0) y1)
+(Merge$P$PCons) = λy0 λy1 λx0 λx (x Merge$P$PCons$PCons Merge$P$PCons$PNil x0 y0 y1)
 
 (Merge$P$PNil) = λx0 (Merge$R0 x0)
 
-(Merge$P) = λy0 λx (((x Merge$P$PCons) Merge$P$PNil) y0)
+(Merge$P) = λy0 λx (x Merge$P$PCons Merge$P$PNil y0)
 
 (Unpack$F0$R0) = λcmp λh h
 
-(Unpack$F0$R1) = λcmp λx$0 λx$1 ((Unpack cmp) ((MergePair cmp) ((Cons x$0) x$1)))
+(Unpack$F0$R1) = λcmp λx$0 λx$1 (Unpack cmp (MergePair cmp (Cons x$0 x$1)))
 
-(Unpack$F0$P$P$PCons) = λy0 λy1 λx0 λx1 (((Unpack$F0$R1 x0) x1) ((Cons y0) y1))
+(Unpack$F0$P$P$PCons) = λy0 λy1 λx0 λx1 (Unpack$F0$R1 x0 x1 (Cons y0 y1))
 
-(Unpack$F0$P$P$PNil) = λx0 λx1 ((Unpack$F0$R0 x0) x1)
+(Unpack$F0$P$P$PNil) = λx0 λx1 (Unpack$F0$R0 x0 x1)
 
-(Unpack$F0$P$P) = λy0 λx0 λx ((((x Unpack$F0$P$P$PCons) Unpack$F0$P$P$PNil) x0) y0)
+(Unpack$F0$P$P) = λy0 λx0 λx (x Unpack$F0$P$P$PCons Unpack$F0$P$P$PNil x0 y0)
 
-(Unpack$F0$P) = λy0 λx ((Unpack$F0$P$P x) y0)
+(Unpack$F0$P) = λy0 λx (Unpack$F0$P$P x y0)
 
-(MergePair$F0$R0) = λcmp λh1 λh2 λt ((Cons (((Merge cmp) h1) h2)) ((MergePair cmp) t))
+(MergePair$F0$R0) = λcmp λh1 λh2 λt (Cons (Merge cmp h1 h2) (MergePair cmp t))
 
-(MergePair$F0$R1) = λcmp λx$0 λx$1 ((Cons x$0) x$1)
+(MergePair$F0$R1) = λcmp λx$0 λx$1 (Cons x$0 x$1)
 
-(MergePair$F0$P$P$PCons) = λy0 λy1 λx0 λx1 ((((MergePair$F0$R0 x0) x1) y0) y1)
+(MergePair$F0$P$P$PCons) = λy0 λy1 λx0 λx1 (MergePair$F0$R0 x0 x1 y0 y1)
 
-(MergePair$F0$P$P$PNil) = λx0 λx1 (((MergePair$F0$R1 x0) x1) Nil)
+(MergePair$F0$P$P$PNil) = λx0 λx1 (MergePair$F0$R1 x0 x1 Nil)
 
-(MergePair$F0$P$P) = λy0 λx0 λx ((((x MergePair$F0$P$P$PCons) MergePair$F0$P$P$PNil) x0) y0)
+(MergePair$F0$P$P) = λy0 λx0 λx (x MergePair$F0$P$P$PCons MergePair$F0$P$P$PNil x0 y0)
 
-(MergePair$F0$P) = λy0 λx ((MergePair$F0$P$P x) y0)
+(MergePair$F0$P) = λy0 λx (MergePair$F0$P$P x y0)

--- a/tests/snapshots/encode_pattern_match__non_matching_fst_arg.hvm.snap
+++ b/tests/snapshots/encode_pattern_match__non_matching_fst_arg.hvm.snap
@@ -10,10 +10,10 @@ input_file: tests/golden_tests/encode_pattern_match/non_matching_fst_arg.hvm
 
 (Foo$R0) = λx x
 
-(Foo$R1) = λx ((Foo x) x)
+(Foo$R1) = λx (Foo x x)
 
 (Foo$P$Ptrue) = λx0 (Foo$R1 x0)
 
 (Foo$P$Pfalse) = λx0 (Foo$R0 x0)
 
-(Foo$P) = λy0 λx (((x Foo$P$Ptrue) Foo$P$Pfalse) y0)
+(Foo$P) = λy0 λx (x Foo$P$Ptrue Foo$P$Pfalse y0)

--- a/tests/snapshots/flatten_rules__already_flat.hvm.snap
+++ b/tests/snapshots/flatten_rules__already_flat.hvm.snap
@@ -6,14 +6,14 @@ input_file: tests/golden_tests/flatten_rules/already_flat.hvm
 
 (Rule2 a) = λx x
 
-(Rule3 a b c d) = (((a b) c) d)
+(Rule3 a b c d) = (a b c d)
 
 (Rule4 (CtrA)) = λx x
 (Rule4 (CtrB x)) = x
 (Rule4 x) = x
 
 (Rule5 (CtrA1 a) b) = (a b)
-(Rule5 (CtrA2 a1 a2) b) = ((a1 a2) b)
+(Rule5 (CtrA2 a1 a2) b) = (a1 a2 b)
 (Rule5 a (CtrB0)) = a
 (Rule5 a (CtrB1 b)) = (a b)
 (Rule5 (CtrA3 a) (CtrB3 b)) = (a b)
@@ -24,7 +24,7 @@ input_file: tests/golden_tests/flatten_rules/already_flat.hvm
 
 (CtrA1) = λa λCtrA1 λCtrA2 λCtrA3 (CtrA1 a)
 
-(CtrA2) = λa1 λa2 λCtrA1 λCtrA2 λCtrA3 ((CtrA2 a1) a2)
+(CtrA2) = λa1 λa2 λCtrA1 λCtrA2 λCtrA3 (CtrA2 a1 a2)
 
 (CtrA3) = λa λCtrA1 λCtrA2 λCtrA3 (CtrA3 a)
 

--- a/tests/snapshots/flatten_rules__nested.hvm.snap
+++ b/tests/snapshots/flatten_rules__nested.hvm.snap
@@ -2,25 +2,25 @@
 source: tests/golden_tests.rs
 input_file: tests/golden_tests/flatten_rules/nested.hvm
 ---
-(Rule (CtrA a x$0)) = ((Rule$F0 a) x$0)
+(Rule (CtrA a x$0)) = (Rule$F0 a x$0)
 (Rule (CtrB b)) = b
 (Rule x) = x
 
 (CtrB1) = λb λCtrB1 λCtrB2 (CtrB1 b)
 
-(CtrB2) = λa λb λCtrB1 λCtrB2 ((CtrB2 a) b)
+(CtrB2) = λa λb λCtrB1 λCtrB2 (CtrB2 a b)
 
 (CtrC) = λCtrC CtrC
 
-(CtrA) = λa λb λCtrA λCtrB ((CtrA a) b)
+(CtrA) = λa λb λCtrA λCtrB (CtrA a b)
 
 (CtrB) = λa λCtrA λCtrB (CtrB a)
 
 (Rule$F0 a (CtrB1 b)) = (a b)
-(Rule$F0 a (CtrB2 x$0 b)) = (((Rule$F0$F0 a) x$0) b)
+(Rule$F0 a (CtrB2 x$0 b)) = (Rule$F0$F0 a x$0 b)
 (Rule$F0 a b) = (a b)
-(Rule$F0 x$0 x$1) = ((CtrA x$0) x$1)
+(Rule$F0 x$0 x$1) = (CtrA x$0 x$1)
 
 (Rule$F0$F0 a (CtrC) b) = (a b)
-(Rule$F0$F0 a x$0 x$1) = (a ((CtrB2 x$0) x$1))
-(Rule$F0$F0 x$0 x$0 x$1) = ((CtrA x$0) ((CtrB2 x$0) x$1))
+(Rule$F0$F0 a x$0 x$1) = (a (CtrB2 x$0 x$1))
+(Rule$F0$F0 x$0 x$0 x$1) = (CtrA x$0 (CtrB2 x$0 x$1))

--- a/tests/snapshots/flatten_rules__nested2.hvm.snap
+++ b/tests/snapshots/flatten_rules__nested2.hvm.snap
@@ -2,12 +2,12 @@
 source: tests/golden_tests.rs
 input_file: tests/golden_tests/flatten_rules/nested2.hvm
 ---
-(Foo a (Cons b x$0)) = (((Foo$F0 a) b) x$0)
+(Foo a (Cons b x$0)) = (Foo$F0 a b x$0)
 (Foo a b) = (a b)
 
-(Cons) = λh λt λCons λNil ((Cons h) t)
+(Cons) = λh λt λCons λNil (Cons h t)
 
 (Nil) = λCons λNil Nil
 
-(Foo$F0 a b (Cons c d)) = (((a b) c) d)
-(Foo$F0 a x$0 x$1) = (a ((Cons x$0) x$1))
+(Foo$F0 a b (Cons c d)) = (a b c d)
+(Foo$F0 a x$0 x$1) = (a (Cons x$0 x$1))

--- a/tests/snapshots/flatten_rules__nested_0ary.hvm.snap
+++ b/tests/snapshots/flatten_rules__nested_0ary.hvm.snap
@@ -3,12 +3,12 @@ source: tests/golden_tests.rs
 input_file: tests/golden_tests/flatten_rules/nested_0ary.hvm
 ---
 (Unpack cmp (Nil)) = Nil
-(Unpack cmp (Cons h x$0)) = (((Unpack$F0 cmp) h) x$0)
+(Unpack cmp (Cons h x$0)) = (Unpack$F0 cmp h x$0)
 (Unpack cmp xs) = (cmp xs)
 
-(Cons) = λhead λtail λCons λNil ((Cons head) tail)
+(Cons) = λhead λtail λCons λNil (Cons head tail)
 
 (Nil) = λCons λNil Nil
 
 (Unpack$F0 cmp h (Nil)) = h
-(Unpack$F0 cmp x$0 x$1) = (cmp ((Cons x$0) x$1))
+(Unpack$F0 cmp x$0 x$1) = (cmp (Cons x$0 x$1))

--- a/tests/snapshots/readback_lnet__bad_net.hvm.snap
+++ b/tests/snapshots/readback_lnet__bad_net.hvm.snap
@@ -2,5 +2,5 @@
 source: tests/golden_tests.rs
 input_file: tests/golden_tests/readback_lnet/bad_net.hvm
 ---
-Invalid readback:
+Invalid readback: [ReachedRoot]
 *

--- a/tests/snapshots/readback_lnet__nested_let.hvm.snap
+++ b/tests/snapshots/readback_lnet__nested_let.hvm.snap
@@ -2,4 +2,4 @@
 source: tests/golden_tests.rs
 input_file: tests/golden_tests/readback_lnet/nested_let.hvm
 ---
-let (c, b) = ((2, 4), (3, 6)); let (a, *) = b; a
+let (a, *) = let (c, b) = ((2, 4), (3, 6)); b; a

--- a/tests/snapshots/run_single_files__list_reverse.hvm.snap
+++ b/tests/snapshots/run_single_files__list_reverse.hvm.snap
@@ -2,4 +2,4 @@
 source: tests/golden_tests.rs
 input_file: tests/golden_tests/run_single_files/list_reverse.hvm
 ---
-λa λ* ((a 1) λb λ* ((b 2) λc λ* ((c 3) λ* λd d)))
+λa λ* (a 1 λb λ* (b 2 λc λ* (c 3 λ* λd d)))

--- a/tests/snapshots/run_single_files__queue.hvm.snap
+++ b/tests/snapshots/run_single_files__queue.hvm.snap
@@ -2,4 +2,4 @@
 source: tests/golden_tests.rs
 input_file: tests/golden_tests/run_single_files/queue.hvm
 ---
-λa λ* ((a 1) λb λ* ((b 2) λc λ* ((c 3) λ* λd d)))
+λa λ* (a 1 λb λ* (b 2 λc λ* (c 3 λ* λd d)))

--- a/tests/snapshots/run_single_files__tuple_rots.hvm.snap
+++ b/tests/snapshots/run_single_files__tuple_rots.hvm.snap
@@ -2,4 +2,4 @@
 source: tests/golden_tests.rs
 input_file: tests/golden_tests/run_single_files/tuple_rots.hvm
 ---
-λa ((((((((a 5) 6) 7) 8) 1) 2) 3) 4)
+λa (a 5 6 7 8 1 2 3 4)


### PR DESCRIPTION
(Based on #73 to avoid annoying merge conflicts.)

- combines the logic of `net_to_term_linear` and `net_to_term_non_linear`, as they were rather duplicative
- adds a cli flag to toggle between linear and non-linear readback
- improves the performance of readback by avoiding allocation of intermediate strings when printing
- prints chained applications without unnecessary parens (i.e. `(a b c)` instead of `((a b) c)`
- reworks the let insertion algorithm – now it always inserts at the lowest common ancestor of the uses of its variables, ignoring the free variables in `val`; this improves the readback of nested tuple destructures