### PR TITLE
Fix tuple defs applications

### DIFF
--- a/src/term/transform/encode_pattern_matching.rs
+++ b/src/term/transform/encode_pattern_matching.rs
@@ -167,6 +167,7 @@ fn make_leaf_pattern_matching_case(
         let ctr_term = ctr_args.fold(Term::Ref { def_id: ctr_ref_id }, Term::arg_call);
         Term::App { tag: Tag::Static, fun: Box::new(term), arg: Box::new(ctr_term) }
       }
+      // As the destructuring of the tuple happens later, we just pass the tuple itself.
       (_, Pattern::Tup(..)) => Term::arg_call(term, arg_use.next().unwrap()),
       (Pattern::Tup(box Pattern::Var(fst), box Pattern::Var(snd)), Pattern::Var(..)) => {
         let fst = if let Some(nam) = fst { Term::Var { nam: nam.clone() } } else { Term::Era };

--- a/src/term/transform/encode_pattern_matching.rs
+++ b/src/term/transform/encode_pattern_matching.rs
@@ -167,7 +167,7 @@ fn make_leaf_pattern_matching_case(
         let ctr_term = ctr_args.fold(Term::Ref { def_id: ctr_ref_id }, Term::arg_call);
         Term::App { tag: Tag::Static, fun: Box::new(term), arg: Box::new(ctr_term) }
       }
-      (_, Pattern::Tup(..)) => arg_use.clone().fold(term, Term::arg_call),
+      (_, Pattern::Tup(..)) => Term::arg_call(term, arg_use.next().unwrap()),
       (Pattern::Tup(box Pattern::Var(fst), box Pattern::Var(snd)), Pattern::Var(..)) => {
         let fst = if let Some(nam) = fst { Term::Var { nam: nam.clone() } } else { Term::Era };
         let snd = if let Some(nam) = snd { Term::Var { nam: nam.clone() } } else { Term::Era };

--- a/tests/golden_tests/encode_pattern_match/concat_def.hvm
+++ b/tests/golden_tests/encode_pattern_match/concat_def.hvm
@@ -1,0 +1,4 @@
+String.concat (a_len, a_buf) (b_len, b_buf) =
+  ((+ a_len b_len), @#Str x (#Str a_buf (#Str b_buf x)))
+
+main = (String.concat (2, @#Str x (42, (43, x))) (2, @#Str x (44, (45, x))))

--- a/tests/snapshots/compile_file__fst_fst.hvm.snap
+++ b/tests/snapshots/compile_file__fst_fst.hvm.snap
@@ -3,9 +3,10 @@ source: tests/golden_tests.rs
 input_file: tests/golden_tests/compile_file/fst_fst.hvm
 ---
 @3 = ([a *] ([b *] [a b]))
-@4 = ({3 a [(a b) *]} ({5 c [c *]} b))
+@4 = (a (b c))
+& @3 ~ (b (a c))
 @5 = (a (b c))
-& @4 ~ (b (a c))
+& @3 ~ (a (b c))
 @main = a
 & @5 ~ ([#3 #9] ([#4 #12] a))
 

--- a/tests/snapshots/encode_pattern_match__concat_def.hvm.snap
+++ b/tests/snapshots/encode_pattern_match__concat_def.hvm.snap
@@ -1,0 +1,13 @@
+---
+source: tests/golden_tests.rs
+input_file: tests/golden_tests/encode_pattern_match/concat_def.hvm
+---
+(String.concat) = λx (String.concat$P x)
+
+(main) = (String.concat (2, λ#Str x (42, (43, x))) (2, λ#Str x (44, (45, x))))
+
+(String.concat$R0) = λ%0 let (a_len, a_buf) = %0; λ%0 let (b_len, b_buf) = %0; ((+ a_len b_len), λ#Str x (#Str a_buf (#Str b_buf x)))
+
+(String.concat$P$P) = λy0 λx0 (String.concat$R0 x0 y0)
+
+(String.concat$P) = λy0 λx (String.concat$P$P x y0)


### PR DESCRIPTION
The desugar for String.concat was generating a wrong pattern definition:
```
(String.concat$P$P) = λy0 λx0 (String.concat$R0 x0 y0 x0 y0)
```