### PR TITLE
[sc-305] Simplify the generated encoding for pattern matching

### DIFF
--- a/src/term/transform/encode_pattern_matching.rs
+++ b/src/term/transform/encode_pattern_matching.rs
@@ -378,7 +378,7 @@ impl Term {
     Term::App { tag: Tag::Static, fun: Box::new(term), arg }
   }
 
-  /// Returns a sequence representing whether the lambda arg is binded or discarded
+  /// Returns a sequence representing whether consecutive lambda args are binded or discarded
   ///
   /// # Example
   ///

--- a/src/term/transform/encode_pattern_matching.rs
+++ b/src/term/transform/encode_pattern_matching.rs
@@ -43,7 +43,7 @@ fn make_pattern_matching_def(book: &mut Book, def_id: DefId, def_type: &[Type]) 
   // First create a definition for each rule body
   let mut rule_bodies = vec![];
   for rule in def.rules.iter_mut() {
-    let body = std::mem::replace(&mut rule.body, Term::Era);
+    let body = std::mem::take(&mut rule.body);
     let body = make_rule_body(body, &rule.pats);
     rule_bodies.push(body);
   }
@@ -146,40 +146,61 @@ fn make_leaf_pattern_matching_case(
   // The term we're building
   let term = Term::Ref { def_id: rule_def_id };
 
+  // The lambdas  of the rule we're calling
+  let lambdas_usage = &mut book.defs[&rule_def_id].rules[0].body.lambdas_usage().into_iter();
+
   let (num_new_args, num_old_args) = get_pat_arg_count(&match_path);
   let old_args = (0 .. num_old_args).map(|x| Name(format!("x{x}")));
   let new_args = (0 .. num_new_args).map(|x| Name(format!("y{x}")));
 
-  let mut arg_use = old_args.clone().chain(new_args.clone());
+  let arg_use = &mut old_args.clone().chain(new_args.clone());
+
+  fn next(
+    usage: &mut impl Iterator<Item = Option<()>>,
+    args: &mut impl Iterator<Item = Name>,
+  ) -> Option<Name> {
+    usage.next().zip(args.next()).map(|(usage, arg)| usage.map(|_| arg)).flatten()
+  }
+
+  fn into_iter(
+    usage: impl Iterator<Item = Option<()>>,
+    args: impl Iterator<Item = Name>,
+  ) -> impl Iterator<Item = Option<Name>> {
+    usage.zip(args).map(|(usage, arg)| usage.map(|_| arg))
+  }
 
   // Add the applications to call the rule body
   let term = match_path.iter().zip(&rule.pats).fold(term, |term, (matched, pat)| {
     match (matched, pat) {
-      (Pattern::Var(_), Pattern::Var(_)) => Term::arg_call(term, arg_use.next().unwrap()),
+      (Pattern::Var(_), Pattern::Var(_)) => Term::optional_arg_call(term, next(lambdas_usage, arg_use)),
       (Pattern::Ctr(_, vars), Pattern::Ctr(_, _)) => {
-        vars.iter().fold(term, |term, _| Term::arg_call(term, arg_use.next().unwrap()))
+        vars.iter().fold(term, |term, _| Term::optional_arg_call(term, next(lambdas_usage, arg_use)))
       }
       // This particular rule was not matching on this arg but due to the other rules we had to match on a constructor.
       // So, to call the rule body we have to recreate the constructor.
       // (On scott encoding, if one of the cases is matched we must also match on all the other constructors for this arg)
       (Pattern::Ctr(ctr_nam, vars), Pattern::Var(_)) => {
-        let ctr_ref_id = book.def_names.def_id(ctr_nam).unwrap();
         let ctr_args = vars.iter().map(|_| arg_use.next().unwrap());
-        let ctr_term = ctr_args.fold(Term::Ref { def_id: ctr_ref_id }, Term::arg_call);
+        
+        // If the rule lambda is discarding the Ctr, we don't need to re-build it
+        let ctr_term = if lambdas_usage.next().flatten().is_none() {
+          Term::Era
+        } else {
+          let ctr_ref_id = book.def_names.def_id(ctr_nam).unwrap();
+          ctr_args.fold(Term::Ref { def_id: ctr_ref_id }, Term::arg_call)
+        };
+
         Term::App { tag: Tag::Static, fun: Box::new(term), arg: Box::new(ctr_term) }
       }
       // As the destructuring of the tuple happens later, we just pass the tuple itself.
-      (_, Pattern::Tup(..)) => Term::arg_call(term, arg_use.next().unwrap()),
-      (Pattern::Tup(box Pattern::Var(fst), box Pattern::Var(snd)), Pattern::Var(..)) => {
-        let fst = if let Some(nam) = fst { Term::Var { nam: nam.clone() } } else { Term::Era };
-        let snd = if let Some(nam) = snd { Term::Var { nam: nam.clone() } } else { Term::Era };
-        Term::Tup { fst: Box::new(fst), snd: Box::new(snd) }
-      }
+      (Pattern::Var(_), Pattern::Tup(..)) => Term::optional_arg_call(term, next(lambdas_usage, arg_use)),
       (Pattern::Num(MatchNum::Zero), Pattern::Num(MatchNum::Zero)) => {
-        arg_use.clone().fold(term, Term::arg_call)
+        let optional_args = into_iter(lambdas_usage.clone(), arg_use.clone());
+        optional_args.fold(term, Term::optional_arg_call)
       }
       (Pattern::Num(MatchNum::Succ { .. }), Pattern::Num(MatchNum::Succ { .. })) => {
-        arg_use.clone().fold(term, Term::arg_call)
+        let optional_args = into_iter(lambdas_usage.clone(), arg_use.clone());
+        optional_args.fold(term, Term::optional_arg_call)
       }
       (Pattern::Var(..), Pattern::Num(..)) => term,
       (Pattern::Ctr(..), _) => unreachable!(),
@@ -353,6 +374,39 @@ impl Term {
 
   fn arg_call(term: Term, arg: Name) -> Term {
     Term::App { tag: Tag::Static, fun: Box::new(term), arg: Box::new(Term::Var { nam: arg }) }
+  }
+
+  fn optional_arg_call(term: Term, arg: Option<Name>) -> Term {
+    let arg = Box::new(arg.map_or(Term::Era, |nam| Term::Var { nam }));
+    Term::App { tag: Tag::Static, fun: Box::new(term), arg }
+  }
+
+  // Returns a sequence representing whether the lambda arg is binded or ignored
+  fn lambdas_usage(&self) -> Vec<Option<()>> {
+    fn go(term: &Term, vec: &mut Vec<Option<()>>) {
+      match term {
+        Term::Lam { nam: None, bod, .. } => {
+          vec.push(None);
+          go(bod, vec);
+        }
+        Term::Lam { nam: Some(_), bod, .. } => {
+          vec.push(Some(()));
+          go(bod, vec);
+        }
+        Term::Let { nxt, .. } | Term::Dup { nxt, .. } => {
+          go(nxt, vec);
+        }
+        _ => {}
+      }
+    }
+
+    let mut term = self.clone();
+    term.make_var_names_unique();
+    term.linearize_vars();
+
+    let mut res = Vec::new();
+    go(&term, &mut res);
+    res
   }
 }
 

--- a/tests/golden_tests/compile_file/list_merge_sort.hvm
+++ b/tests/golden_tests/compile_file/list_merge_sort.hvm
@@ -1,0 +1,31 @@
+data Bool = True | False
+data List = (Cons head tail) | Nil
+
+If True then else = then
+If False then else = else
+
+Pure x = (Cons x Nil)
+
+Map Nil f = Nil
+Map (Cons h t) f = (Cons (f h) (Map t f))
+
+MergeSort cmp xs = (Unpack cmp (Map xs Pure))
+
+Unpack cmp Nil = Nil
+Unpack cmp (Cons h Nil) = h
+Unpack cmp xs = (Unpack cmp (MergePair cmp xs))
+
+MergePair cmp (Cons h1 (Cons h2 t)) = (Cons (Merge cmp h1 h2) (MergePair cmp t))
+MergePair cmp xs = xs
+
+Merge cmp Nil ys = ys
+Merge cmp xs Nil = xs
+Merge cmp (Cons xh xt) (Cons yh yt) =
+  (If (cmp xh yh)
+    let ys = (Cons yh yt)
+    (Cons xh (Merge cmp xt ys))
+    let xs = (Cons xh xt)
+    (Cons yh (Merge cmp xs yt))
+  )
+
+main = MergeSort

--- a/tests/golden_tests/encode_pattern_match/pattern_match_encoding.hvm
+++ b/tests/golden_tests/encode_pattern_match/pattern_match_encoding.hvm
@@ -1,0 +1,6 @@
+data MyType = (A a) | (B b) | (C c) | (D d1 d2) | (E e1 e2)
+
+Foo (A a) = 100
+Foo * = 200
+
+main = (Foo A 2)

--- a/tests/snapshots/compile_file__and.hvm.snap
+++ b/tests/snapshots/compile_file__and.hvm.snap
@@ -2,9 +2,9 @@
 source: tests/golden_tests.rs
 input_file: tests/golden_tests/compile_file/and.hvm
 ---
-@5 = (* @false)
 @6 = (a a)
-@9 = (a ({2 @6 {2 @5 (a b)}} b))
+@8 = (* @false)
+@9 = (a ({2 @6 {2 @8 (a b)}} b))
 @false = {2 * {2 a a}}
 @main = a
 & @9 ~ (@true (@false a))

--- a/tests/snapshots/compile_file__list_merge_sort.hvm.snap
+++ b/tests/snapshots/compile_file__list_merge_sort.hvm.snap
@@ -1,0 +1,28 @@
+---
+source: tests/golden_tests.rs
+input_file: tests/golden_tests/compile_file/list_merge_sort.hvm
+---
+@Cons = (a (b {4 (a (b c)) {4 * c}}))
+@F = (a (* a))
+@G = (* (a a))
+@J = (* @Nil)
+@K = (a ({4 @K {4 @J (b c)}} ({3 b (a d)} {4 (d (c e)) {4 * e}})))
+@MergeSort = (a ({4 @K {4 @J (@Pure {4 @Q {4 @R (a b)}})}} b))
+@Nil = {4 * {4 a a}}
+@Pure = (a {4 (a (@Nil b)) {4 * b}})
+@Q = (a ({4 @i {4 @j (b (a c))}} (b c)))
+@R = (* @Nil)
+@V = (a ({4 @o {4 @p (b (a c))}} (b c)))
+@W = (* @Nil)
+@b = ({15 a {17 b c}} ({19 {4 @b {4 @c (d (e (f g)))}} h} ({5 d {7 i (j (c {2 @F {2 @G ({4 (k (l m)) {4 * m}} ({4 (a (g n)) {4 * n}} o))}}))}} ({9 e {11 k j}} ({13 f {4 @d {4 @e (i ({4 (b (h p)) {4 * p}} l))}}} o)))))
+@c = (* @s)
+@d = (a (b (c ({4 @b {4 @c (c (a (b d)))}} d))))
+@e = (* (a a))
+@i = (a ({4 @V {4 @W (b {4 @i {4 @j (c (d e))}})}} ({21 {23 b f} c} ({4 @d {4 @e (f (a d))}} e))))
+@j = (* (a a))
+@main = @MergeSort
+@o = (a ({4 @V {4 @W (b c)}} ({23 b d} ({4 @d {4 @e (d (a e))}} {4 (e (c f)) {4 * f}}))))
+@p = (* @t)
+@s = (a (b {4 (a (b c)) {4 * c}}))
+@t = (a {4 (a (@Nil b)) {4 * b}})
+

--- a/tests/snapshots/compile_file__scrutinee_reconstruction.hvm.snap
+++ b/tests/snapshots/compile_file__scrutinee_reconstruction.hvm.snap
@@ -2,11 +2,11 @@
 source: tests/golden_tests.rs
 input_file: tests/golden_tests/compile_file/scrutinee_reconstruction.hvm
 ---
-@6 = (* @A)
 @7 = (* (a a))
+@8 = (* @A)
 @A = (a (* a))
 @None = {2 * {2 a a}}
-@Option.or = ({3 a {2 @6 {2 @7 (a b)}}} b)
+@Option.or = ({3 a {2 @8 {2 @7 (a b)}}} b)
 @Some = (a {2 (a b) {2 * b}})
 @main = a
 & @Option.or ~ (b (@None a))

--- a/tests/snapshots/encode_pattern_match__bool.hvm.snap
+++ b/tests/snapshots/encode_pattern_match__bool.hvm.snap
@@ -58,11 +58,11 @@ input_file: tests/golden_tests/encode_pattern_match/bool.hvm
 
 (and3$Ptrue$Ptrue) = and3$R0
 
-(and3$Ptrue$Pfalse) = (and3$R1 true false)
+(and3$Ptrue$Pfalse) = (and3$R1 * *)
 
 (and3$Ptrue) = λx (#bool x and3$Ptrue$Ptrue and3$Ptrue$Pfalse)
 
-(and3$Pfalse) = (and3$R1 false)
+(and3$Pfalse) = (and3$R1 *)
 
 (and4$R0) = λb false
 
@@ -70,9 +70,9 @@ input_file: tests/golden_tests/encode_pattern_match/bool.hvm
 
 (and4$R2) = λa λb true
 
-(and4$Ptrue$Ptrue) = (and4$R2 true true)
+(and4$Ptrue$Ptrue) = (and4$R2 * *)
 
-(and4$Ptrue$Pfalse) = (and4$R1 true)
+(and4$Ptrue$Pfalse) = (and4$R1 *)
 
 (and4$Ptrue) = λx (#bool x and4$Ptrue$Ptrue and4$Ptrue$Pfalse)
 

--- a/tests/snapshots/encode_pattern_match__list_merge_sort.hvm.snap
+++ b/tests/snapshots/encode_pattern_match__list_merge_sort.hvm.snap
@@ -52,7 +52,7 @@ input_file: tests/golden_tests/encode_pattern_match/list_merge_sort.hvm
 
 (Unpack$P$PCons) = λy0 λy1 λx0 (Unpack$R1 x0 y0 y1)
 
-(Unpack$P$PNil) = λx0 (Unpack$R0 x0)
+(Unpack$P$PNil) = λx0 (Unpack$R0 *)
 
 (Unpack$P) = λy0 λx ((#List x Unpack$P$PCons Unpack$P$PNil) y0)
 
@@ -62,7 +62,7 @@ input_file: tests/golden_tests/encode_pattern_match/list_merge_sort.hvm
 
 (MergePair$P$PCons) = λy0 λy1 λx0 (MergePair$R0 x0 y0 y1)
 
-(MergePair$P$PNil) = λx0 (MergePair$R1 x0 Nil)
+(MergePair$P$PNil) = λx0 (MergePair$R1 * Nil)
 
 (MergePair$P) = λy0 λx ((#List x MergePair$P$PCons MergePair$P$PNil) y0)
 
@@ -74,11 +74,11 @@ input_file: tests/golden_tests/encode_pattern_match/list_merge_sort.hvm
 
 (Merge$P$PCons$PCons) = λy0 λy1 λx0 λx1 λx2 (Merge$R2 x0 x1 x2 y0 y1)
 
-(Merge$P$PCons$PNil) = λx0 λx1 λx2 (Merge$R1 x0 (Cons x1 x2))
+(Merge$P$PCons$PNil) = λx0 λx1 λx2 (Merge$R1 * (Cons x1 x2))
 
 (Merge$P$PCons) = λy0 λy1 λx0 λx ((#List x Merge$P$PCons$PCons Merge$P$PCons$PNil) x0 y0 y1)
 
-(Merge$P$PNil) = λx0 (Merge$R0 x0)
+(Merge$P$PNil) = λx0 (Merge$R0 *)
 
 (Merge$P) = λy0 λx ((#List x Merge$P$PCons Merge$P$PNil) y0)
 
@@ -88,7 +88,7 @@ input_file: tests/golden_tests/encode_pattern_match/list_merge_sort.hvm
 
 (Unpack$F0$P$P$PCons) = λy0 λy1 λx0 λx1 (Unpack$F0$R1 x0 x1 (Cons y0 y1))
 
-(Unpack$F0$P$P$PNil) = λx0 λx1 (Unpack$F0$R0 x0 x1)
+(Unpack$F0$P$P$PNil) = λx0 λx1 (Unpack$F0$R0 * x1)
 
 (Unpack$F0$P$P) = λy0 λx0 λx ((#List x Unpack$F0$P$P$PCons Unpack$F0$P$P$PNil) x0 y0)
 
@@ -100,7 +100,7 @@ input_file: tests/golden_tests/encode_pattern_match/list_merge_sort.hvm
 
 (MergePair$F0$P$P$PCons) = λy0 λy1 λx0 λx1 (MergePair$F0$R0 x0 x1 y0 y1)
 
-(MergePair$F0$P$P$PNil) = λx0 λx1 (MergePair$F0$R1 x0 x1 Nil)
+(MergePair$F0$P$P$PNil) = λx0 λx1 (MergePair$F0$R1 * x1 Nil)
 
 (MergePair$F0$P$P) = λy0 λx0 λx ((#List x MergePair$F0$P$P$PCons MergePair$F0$P$P$PNil) x0 y0)
 

--- a/tests/snapshots/encode_pattern_match__nested_let_tup.hvm.snap
+++ b/tests/snapshots/encode_pattern_match__nested_let_tup.hvm.snap
@@ -28,12 +28,12 @@ input_file: tests/golden_tests/encode_pattern_match/nested_let_tup.hvm
 
 (main$match$1$F0$R0) = λi λ%0 let (j, k) = %0; j
 
-(main$match$1$F0$P$P) = λy0 λx0 (main$match$1$F0$R0 x0 y0)
+(main$match$1$F0$P$P) = λy0 λx0 (main$match$1$F0$R0 * y0)
 
 (main$match$1$F0$P) = λy0 λx (main$match$1$F0$P$P x y0)
 
 (main$match$3$F0$R0) = λa λ%0 let (b, c) = %0; (main$match$2 b)
 
-(main$match$3$F0$P$P) = λy0 λx0 (main$match$3$F0$R0 x0 y0)
+(main$match$3$F0$P$P) = λy0 λx0 (main$match$3$F0$R0 * y0)
 
 (main$match$3$F0$P) = λy0 λx (main$match$3$F0$P$P x y0)

--- a/tests/snapshots/encode_pattern_match__pattern_match_encoding.hvm.snap
+++ b/tests/snapshots/encode_pattern_match__pattern_match_encoding.hvm.snap
@@ -1,0 +1,31 @@
+---
+source: tests/golden_tests.rs
+input_file: tests/golden_tests/encode_pattern_match/pattern_match_encoding.hvm
+---
+(Foo) = λx (#MyType x Foo$PA Foo$PB Foo$PC Foo$PD Foo$PE)
+
+(main) = (Foo A 2)
+
+(A) = λa λ#MyType A λ#MyType B λ#MyType C λ#MyType D λ#MyType E (A a)
+
+(B) = λb λ#MyType A λ#MyType B λ#MyType C λ#MyType D λ#MyType E (B b)
+
+(C) = λc λ#MyType A λ#MyType B λ#MyType C λ#MyType D λ#MyType E (C c)
+
+(D) = λd1 λd2 λ#MyType A λ#MyType B λ#MyType C λ#MyType D λ#MyType E (D d1 d2)
+
+(E) = λe1 λe2 λ#MyType A λ#MyType B λ#MyType C λ#MyType D λ#MyType E (E e1 e2)
+
+(Foo$R0) = λa 100
+
+(Foo$R1) = λ* 200
+
+(Foo$PA) = λy0 (Foo$R0 *)
+
+(Foo$PB) = λy0 (Foo$R1 *)
+
+(Foo$PC) = λy0 (Foo$R1 *)
+
+(Foo$PD) = λy0 λy1 (Foo$R1 *)
+
+(Foo$PE) = λy0 λy1 (Foo$R1 *)


### PR DESCRIPTION
This pr deals with the this part of the task:

- [x] If we know an argument will not be used, we can not pass it forward, which reduces the number of generated nodes.

Making the current program and compilation of:
```rs
data MyType = (A a) | (B b) | (C c) | (D d1 d2) | (E e1 e2)

Foo (A a) = R0
Foo * = R1
```
```rs
Foo = @x (x Foo$A Foo$B Foo$C Foo$D Foo$E)
Foo$R0 = @a R0
Foo$R1 = @* R1
Foo$A = @a (Foo$R0 a)
Foo$B = @b (Foo$R1 (B b))
Foo$C = @c (Foo$R1 (C c))
Foo$D = @d1 @d2 (Foo$R1 (D d1 d2))
Foo$E = @e1 @e2 (Foo$R1 (E e1 e2))
```

into this:
```rs
Foo = @x (x Foo$A Foo$B Foo$C Foo$D Foo$E)
Foo$R0 = @a R0
Foo$R1 = @* R1
Foo$A = @a (Foo$R0 *)
Foo$B = @b (Foo$R1 *)
Foo$C = @c (Foo$R1 *)
Foo$D = @d1 @d2 (Foo$R1 *)
Foo$E = @e1 @e2 (Foo$R1 *)
```

Instead of merging the now identical definitions of `Foo$B & Foo$C` and `Foo$D & Foo$E`, this can be done in a later pass to merge all identical definitions without further complicating the pattern matching encoding pass.