### PR TITLE
[sc-311] fix ref to ref removal pass

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,8 +51,9 @@ pub fn desugar_book(book: &mut Book, opt_level: OptimizationLevel) -> Result<Def
   }
   book.detach_supercombinators();
   if opt_level >= OptimizationLevel::Heavy {
-    book.simplify_ref_to_ref(main)?;
+    book.simplify_ref_to_ref()?;
   }
+  book.simplify_main_ref(main);
   if opt_level >= OptimizationLevel::Heavy {
     book.prune(main);
   }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@ pub fn desugar_book(book: &mut Book, opt_level: OptimizationLevel) -> Result<Def
   }
   book.detach_supercombinators();
   if opt_level >= OptimizationLevel::Heavy {
-    book.simplify_ref_to_ref()?;
+    book.simplify_ref_to_ref(main)?;
   }
   if opt_level >= OptimizationLevel::Heavy {
     book.prune(main);

--- a/src/term/transform/mod.rs
+++ b/src/term/transform/mod.rs
@@ -11,5 +11,6 @@ pub mod flatten;
 pub mod linearize;
 pub mod resolve_ctrs_in_pats;
 pub mod resolve_refs;
+pub mod simplify_main_ref;
 pub mod simplify_ref_to_ref;
 pub mod unique_names;

--- a/src/term/transform/simplify_main_ref.rs
+++ b/src/term/transform/simplify_main_ref.rs
@@ -3,7 +3,7 @@ use crate::term::{Book, DefId, Term};
 impl Book {
   /// When main is simply directly calling another function, we substitute the ref with a copy of its body.
   /// 
-  /// This is performed because Hvm-Core produces inconsistent outputs in the parralel mode when such pattern is present
+  /// This is performed because Hvm-Core produces inconsistent outputs in the parallel mode when such pattern is present
   pub fn simplify_main_ref(&mut self, main: DefId) {
     if let Term::Ref { def_id } = &self.defs.get(&main).unwrap().rules[0].body {
       let rule_body = self.defs.get(def_id).unwrap().rules[0].body.clone();

--- a/src/term/transform/simplify_main_ref.rs
+++ b/src/term/transform/simplify_main_ref.rs
@@ -1,0 +1,14 @@
+use crate::term::{Book, DefId, Term};
+
+impl Book {
+  /// When main is simply directly calling another function, we substitute the ref with a copy of its body.
+  /// 
+  /// This is performed because Hvm-Core produces inconsistent outputs in the parralel mode when such pattern is present
+  pub fn simplify_main_ref(&mut self, main: DefId) {
+    if let Term::Ref { def_id } = &self.defs.get(&main).unwrap().rules[0].body {
+      let rule_body = self.defs.get(def_id).unwrap().rules[0].body.clone();
+      let main_body = &mut self.defs.get_mut(&main).unwrap().rules[0].body;
+      *main_body = rule_body;
+    }
+  }
+}

--- a/src/term/transform/simplify_main_ref.rs
+++ b/src/term/transform/simplify_main_ref.rs
@@ -5,7 +5,7 @@ impl Book {
   /// 
   /// This is performed because Hvm-Core produces inconsistent outputs in the parallel mode when such pattern is present
   pub fn simplify_main_ref(&mut self, main: DefId) {
-    if let Term::Ref { def_id } = &self.defs.get(&main).unwrap().rules[0].body {
+    while let Term::Ref { def_id } = &self.defs.get(&main).unwrap().rules[0].body {
       let rule_body = self.defs.get(def_id).unwrap().rules[0].body.clone();
       let main_body = &mut self.defs.get_mut(&main).unwrap().rules[0].body;
       *main_body = rule_body;

--- a/src/term/transform/simplify_ref_to_ref.rs
+++ b/src/term/transform/simplify_ref_to_ref.rs
@@ -7,7 +7,7 @@ impl Book {
   // When we find a function that is simply directly calling another function,
   // substitutes all occurences of that function to the one being called, avoiding the unnecessary redirect.
   // In case there is a long chaing of ref-to-ref-to-ref, we substitute values by the last function in the chain.
-  pub fn simplify_ref_to_ref(&mut self, main: DefId) -> Result<(), String> {
+  pub fn simplify_ref_to_ref(&mut self) -> Result<(), String> {
     let mut ref_map: HashMap<DefId, DefId> = HashMap::new();
     // Find to which defs we're mapping the ones that are just references.
     for def_id in self.def_names.def_ids() {
@@ -37,12 +37,6 @@ impl Book {
       subst_ref_to_ref(&mut subst_body, &ref_map);
       let body = &mut self.defs.get_mut(&def_id).unwrap().rules[0].body;
       *body = subst_body;
-    }
-
-    if let Term::Ref { def_id } = &self.defs.get(&main).unwrap().rules[0].body {
-      let rule_body = self.defs.get(def_id).unwrap().rules[0].body.clone();
-      let main_body = &mut self.defs.get_mut(&main).unwrap().rules[0].body;
-      *main_body = rule_body;
     }
 
     Ok(())

--- a/src/term/transform/simplify_ref_to_ref.rs
+++ b/src/term/transform/simplify_ref_to_ref.rs
@@ -39,12 +39,10 @@ impl Book {
       *body = subst_body;
     }
 
-    match &self.defs.get(&main).unwrap().rules[0].body {
-      Term::Ref { def_id } => {
-        self.defs.get_mut(&main).unwrap().rules[0].body =
-          self.defs.get(def_id).unwrap().rules[0].body.clone();
-      }
-      _ => {}
+    if let Term::Ref { def_id } = &self.defs.get(&main).unwrap().rules[0].body {
+      let rule_body = self.defs.get(def_id).unwrap().rules[0].body.clone();
+      let main_body = &mut self.defs.get_mut(&main).unwrap().rules[0].body;
+      *main_body = rule_body;
     }
 
     Ok(())

--- a/src/term/transform/simplify_ref_to_ref.rs
+++ b/src/term/transform/simplify_ref_to_ref.rs
@@ -5,8 +5,8 @@ use std::collections::HashMap;
 
 impl Book {
   // When we find a function that is simply directly calling another function,
-  // substitutes all occurences of that function to the one being called, avoiding the unnecessary redirect.
-  // In case there is a long chaing of ref-to-ref-to-ref, we substitute values by the last function in the chain.
+  // substitutes all occurrences of that function to the one being called, avoiding the unnecessary redirect.
+  // In case there is a long chain of ref-to-ref-to-ref, we substitute values by the last function in the chain.
   pub fn simplify_ref_to_ref(&mut self) -> Result<(), String> {
     let mut ref_map: HashMap<DefId, DefId> = HashMap::new();
     // Find to which defs we're mapping the ones that are just references.
@@ -29,7 +29,7 @@ impl Book {
       }
     }
 
-    // Substitute all the occurences of ref-to-ref.
+    // Substitute all the occurrences of ref-to-ref.
     for def_id in self.defs.keys().copied().collect::<Vec<_>>() {
       let body = &mut self.defs.get_mut(&def_id).unwrap().rules[0].body;
       // Moving in and out so the borrow checker doesn't complain

--- a/tests/golden_tests/compile_file/long_name.hvm
+++ b/tests/golden_tests/compile_file/long_name.hvm
@@ -1,2 +1,2 @@
 (WowThis_is_a_very_long_name_no_way_ItFits) = λa a
-main = λa (WowThis_is_a_very_long_name_no_way_ItFits a)
+main = λa (WowThis_is_a_very_long_name_no_way_ItFits *)

--- a/tests/golden_tests/compile_file/repeated_name_trucation.hvm
+++ b/tests/golden_tests/compile_file/repeated_name_trucation.hvm
@@ -1,2 +1,3 @@
-main_long_name_that_truncates_to_main = @a @b main_long_name_that_truncates_to_main
-main = @a (main_long_name_that_truncates_to_main a)
+long_name_that_truncates = @a @b long_name_that_truncates
+long_name_that_truncates_too = @a a
+main = (long_name_that_truncates long_name_that_truncates_too)

--- a/tests/golden_tests/run_file/repeated_name_trucation.hvm
+++ b/tests/golden_tests/run_file/repeated_name_trucation.hvm
@@ -1,2 +1,3 @@
-main_long_name_that_truncates_to_main = @a @b main_long_name_that_truncates_to_main
-main = @a (main_long_name_that_truncates_to_main a)
+long_name_that_truncates = @a @b long_name_that_truncates
+long_name_that_truncates_too = @a a
+main = (long_name_that_truncates long_name_that_truncates_too)

--- a/tests/snapshots/compile_file__eta.hvm.snap
+++ b/tests/snapshots/compile_file__eta.hvm.snap
@@ -2,6 +2,5 @@
 source: tests/golden_tests.rs
 input_file: tests/golden_tests/compile_file/eta.hvm
 ---
-@Id = (a a)
-@main = @Id
+@main = (a a)
 

--- a/tests/snapshots/compile_file__linearize_match.hvm.snap
+++ b/tests/snapshots/compile_file__linearize_match.hvm.snap
@@ -2,8 +2,7 @@
 source: tests/golden_tests.rs
 input_file: tests/golden_tests/compile_file/linearize_match.hvm
 ---
-@2 = (?<(@3 @4) a> a)
 @3 = (a a)
 @4 = (<+ a b> (a b))
-@main = @2
+@main = (?<(@3 @4) a> a)
 

--- a/tests/snapshots/compile_file__list_merge_sort.hvm.snap
+++ b/tests/snapshots/compile_file__list_merge_sort.hvm.snap
@@ -6,11 +6,12 @@ input_file: tests/golden_tests/compile_file/list_merge_sort.hvm
 @G = (* (a a))
 @J = (* @Nil)
 @L = {8 a {6 {4 @L {4 @J (b c)}} ({3 b (a d)} {4 {8 d {6 c e}} {4 * e}})}}
-@MergeSort = (a ({4 @L {4 @J (@Pure {4 @Q {4 @R (a b)}})}} b))
+@Map = ({4 @L {4 @J a}} a)
 @Nil = {4 * {4 a a}}
 @Pure = (a {4 {8 a {6 @Nil b}} {4 * b}})
 @Q = {8 a {6 {4 @i {4 @j (b (a c))}} (b c)}}
 @R = (* @Nil)
+@S = (a ({4 @Q {4 @R (a b)}} b))
 @V = {8 a {6 {4 @o {4 @p (b (a c))}} (b c)}}
 @W = (* @Nil)
 @b = {8 {15 a {17 b c}} {6 {19 {4 @b {4 @c (d (e (f g)))}} h} ({5 d {7 i (j (c {2 @F {2 @G ({4 {8 k {6 l m}} {4 * m}} ({4 {8 a {6 g n}} {4 * n}} o))}}))}} ({9 e {11 k j}} ({13 f {4 @d {4 @e (i ({4 {8 b {6 h p}} {4 * p}} l))}}} o)))}}
@@ -19,7 +20,9 @@ input_file: tests/golden_tests/compile_file/list_merge_sort.hvm
 @e = (* (a a))
 @i = {8 a {6 {4 @V {4 @W (b {4 @i {4 @j (c (d e))}})}} ({21 {23 b f} c} ({4 @d {4 @e (f (a d))}} e))}}
 @j = (* (a a))
-@main = @MergeSort
+@main = (a (b c))
+& @S ~ (a (d c))
+& @Map ~ (b (@Pure d))
 @o = {8 a {6 {4 @V {4 @W (b c)}} ({23 b d} ({4 @d {4 @e (d (a e))}} {4 {8 e {6 c f}} {4 * f}}))}}
 @p = (* @t)
 @s = (a (b {4 {8 a {6 b c}} {4 * c}}))

--- a/tests/snapshots/compile_file__long_name.hvm.snap
+++ b/tests/snapshots/compile_file__long_name.hvm.snap
@@ -3,5 +3,6 @@ source: tests/golden_tests.rs
 input_file: tests/golden_tests/compile_file/long_name.hvm
 ---
 @WowThis_is = (a a)
-@main = @WowThis_is
+@main = (* a)
+& @WowThis_is ~ (* a)
 

--- a/tests/snapshots/compile_file__match_mult_linearization.hvm.snap
+++ b/tests/snapshots/compile_file__match_mult_linearization.hvm.snap
@@ -2,8 +2,7 @@
 source: tests/golden_tests.rs
 input_file: tests/golden_tests/compile_file/match_mult_linearization.hvm
 ---
-@2 = (?<(@3 @4) a> a)
 @3 = (<+ a <+ b c>> (a (b c)))
 @4 = (<+ a <+ b <+ c d>>> (a (b (c d))))
-@main = @2
+@main = (?<(@3 @4) a> a)
 

--- a/tests/snapshots/compile_file__nested_eta.hvm.snap
+++ b/tests/snapshots/compile_file__nested_eta.hvm.snap
@@ -2,6 +2,5 @@
 source: tests/golden_tests.rs
 input_file: tests/golden_tests/compile_file/nested_eta.hvm
 ---
-@X = (a a)
-@main = @X
+@main = (a a)
 

--- a/tests/snapshots/compile_file__repeated_name_trucation.hvm.snap
+++ b/tests/snapshots/compile_file__repeated_name_trucation.hvm.snap
@@ -2,7 +2,9 @@
 source: tests/golden_tests.rs
 input_file: tests/golden_tests/compile_file/repeated_name_trucation.hvm
 ---
-@3 = (* @main_long_)
-@main = @main_long_
-@main_long_ = (* @3)
+@2 = (a a)
+@4 = (* @long_name_)
+@long_name_ = (* @4)
+@main = a
+& @long_name_ ~ (@2 a)
 

--- a/tests/snapshots/run_file__repeated_name_trucation.hvm.snap
+++ b/tests/snapshots/run_file__repeated_name_trucation.hvm.snap
@@ -2,4 +2,4 @@
 source: tests/golden_tests.rs
 input_file: tests/golden_tests/run_file/repeated_name_trucation.hvm
 ---
-λ* λ* main_long_name_that_truncates_to_main
+λ* λ* λ* long_name_that_truncates


### PR DESCRIPTION
This pr implements the first option described in the task:

1. One would be to have main be a duplicate of the function it's referencing. This is the simplest option.
2. Another option would be to have the other function be merged with main, replacing all calls to it with calls to main.
