### PR TITLE
[sc-360] Update hvm-lang tagged lambda documentation

### DIFF
--- a/docs/automatic-vectorization-with-tagged-lambdas.md
+++ b/docs/automatic-vectorization-with-tagged-lambdas.md
@@ -37,7 +37,7 @@ In fact, `match` is syntax sugar for a tagged application like the one above. Th
 When an application and a lambda with different tags interact, the application "commutes" through the lambda instead of beta-reducing it. Here is how it works, roughly:
 
 ```rs
-(#A λx #B(b x) a)
+#A (#B λx (b x) a)
 // Reduces to
 #B λc #A((b #A λ$d c) #B(a $d))
 ```

--- a/docs/automatic-vectorization-with-tagged-lambdas.md
+++ b/docs/automatic-vectorization-with-tagged-lambdas.md
@@ -4,8 +4,9 @@ We have seen in [Dups and Sups](dups-and-sups.md) that duplications and superpos
 
 Tagged applications will only annihilate lambdas with the same tag.
 ```rs
-(#A λ#A x(body) arg)
-// Reduces to
+#A(#A λx(body) arg) // #A is the tag.
+// The tag goes before the term.
+// This reduces to
 x = arg; body
 ```
 
@@ -13,12 +14,12 @@ For example, data types can be encoded as tagged lambdas:
 
 ```rs
 // data Bool = T | F
-T = λ#Bool t λ#Bool f t
-F = λ#Bool t λ#Bool f f
+T = #Bool λt #Bool λf t
+F = #Bool λt #Bool λf f
 
 // data List = (Cons x xs) | Nil
-Cons = λx λxs λ#List c λ#List n (#List.Cons.xs (#List.Cons.x c x) xs)
-Nil  =        λ#List c λ#List n n
+Cons = λx λxs #List λc #List λn #List.Cons.xs (#List.Cons.x (c x) xs)
+Nil  =        #List λc #List λn n
 ```
 
 When encoding the pattern matching, the application can then use the same label:
@@ -30,12 +31,12 @@ not = λbool (#Bool bool F T)
 
 In fact, `match` is syntax sugar for a tagged application like the one above. This means that it is not possible to match without using tagged applications.
 
-When an application and a lambda with different tags interact, the application "commutes" through the lambda. Here is how it roughly works:
+When an application and a lambda with different tags interact, the application "commutes" through the lambda instead of beta-reducing it. Here is how it works, roughly:
 
 ```rs
-(#A λ#B x (b x) a)
+(#A λx #B (b x) a)
 // Reduces to
-λ#B c (#A (b λ#A $d c) (#B a $d))
+#B λc #A((b #A λ$d c) #B(a $d))
 ```
 
 This reduction can be hard to grasp, but an accurate way to understand it is that "the application goes through the lambda".

--- a/docs/automatic-vectorization-with-tagged-lambdas.md
+++ b/docs/automatic-vectorization-with-tagged-lambdas.md
@@ -4,8 +4,11 @@ We have seen in [Dups and Sups](dups-and-sups.md) that duplications and superpos
 
 Tagged applications will only annihilate lambdas with the same tag.
 ```rs
-#A(#A λx(body) arg) // #A is the tag.
-// The tag goes before the term.
+
+// V appllication's tag
+  #A(#A λx(body) arg)
+//    ^ lambda's tag
+// The tag must go before the term.
 // This reduces to
 x = arg; body
 ```
@@ -18,7 +21,7 @@ T = #Bool λt #Bool λf t
 F = #Bool λt #Bool λf f
 
 // data List = (Cons x xs) | Nil
-Cons = λx λxs #List λc #List λn #List.Cons.xs (#List.Cons.x (c x) xs)
+Cons = λx λxs #List λc #List λn #List.Cons.xs(#List.Cons.x(c x) xs)
 Nil  =        #List λc #List λn n
 ```
 
@@ -26,7 +29,7 @@ When encoding the pattern matching, the application can then use the same label:
 
 ```rs
 // not = λbool match bool { T: (F) F: (T) } 
-not = λbool (#Bool bool F T)
+not = λbool #Bool(bool F T)
 ```
 
 In fact, `match` is syntax sugar for a tagged application like the one above. This means that it is not possible to match without using tagged applications.
@@ -34,7 +37,7 @@ In fact, `match` is syntax sugar for a tagged application like the one above. Th
 When an application and a lambda with different tags interact, the application "commutes" through the lambda instead of beta-reducing it. Here is how it works, roughly:
 
 ```rs
-(#A λx #B (b x) a)
+(#A λx #B(b x) a)
 // Reduces to
 #B λc #A((b #A λ$d c) #B(a $d))
 ```


### PR DESCRIPTION
It used the old tagged lambda syntax. I updated it to prevent users from getting confused.