### PR TITLE
[sc-332] Separate adt match extraction from num match normalization

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,7 @@ pub fn desugar_book(book: &mut Book, opt_level: OptimizationLevel) -> Result<Def
   book.generate_scott_adts();
   book.resolve_refs();
   encode_pattern_matching(book)?;
+  book.normalize_native_matches()?;
   book.check_unbound_vars()?;
   book.make_var_names_unique();
   book.linearize_vars();
@@ -64,7 +65,7 @@ pub fn encode_pattern_matching(book: &mut Book) -> Result<(), String> {
   book.check_unbound_pats()?;
   book.desugar_let_destructors();
   book.desugar_implicit_match_binds();
-  book.extract_matches()?;
+  book.extract_adt_matches()?;
   book.flatten_rules();
   let def_types = book.infer_def_types()?;
   book.check_exhaustive_patterns(&def_types)?;

--- a/src/term/check/exhaustiveness.rs
+++ b/src/term/check/exhaustiveness.rs
@@ -67,6 +67,7 @@ fn check_pattern(
         }
         next_rules_to_check
       }
+      Type::None => unreachable!(),
     };
 
     // Check that each constructor matches at least one rule and then check the next pattern recursively.
@@ -105,5 +106,6 @@ fn first_ctr_of_type(typ: &Type, adts: &BTreeMap<Name, Adt>) -> String {
     Type::Tup => "(_,_)".to_string(),
     Type::Num => "0".to_string(),
     Type::Adt(adt_name) => adts[adt_name].ctrs.keys().next().unwrap().to_string(),
+    Type::None => unreachable!(),
   }
 }

--- a/src/term/check/type_check.rs
+++ b/src/term/check/type_check.rs
@@ -1,5 +1,4 @@
 use crate::term::{Book, DefId, Definition, Name, Pattern, Type};
-use core::fmt;
 use std::collections::HashMap;
 
 pub type DefinitionTypes = HashMap<DefId, Vec<Type>>;
@@ -52,17 +51,6 @@ fn unify(new: Type, old: &mut Type) -> Result<(), String> {
     _ => (),
   };
   Ok(())
-}
-
-impl fmt::Display for Type {
-  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    match self {
-      Type::Any => write!(f, "any"),
-      Type::Tup => write!(f, "tup"),
-      Type::Num => write!(f, "num"),
-      Type::Adt(nam) => write!(f, "{nam}"),
-    }
-  }
 }
 
 impl Book {

--- a/src/term/display.rs
+++ b/src/term/display.rs
@@ -2,7 +2,7 @@ use std::fmt::{self, Display};
 
 use crate::term::Name;
 
-use super::{Book, DefId, DefNames, Definition, MatchNum, Op, Pattern, Rule, Tag, Term};
+use super::{Book, DefId, DefNames, Definition, MatchNum, Op, Pattern, Rule, Tag, Term, Type};
 
 macro_rules! display {
   ($($x:tt)*) => {
@@ -177,6 +177,17 @@ impl fmt::Display for Name {
   }
 }
 
+impl fmt::Display for Type {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    match self {
+      Type::Any => write!(f, "any"),
+      Type::Tup => write!(f, "tup"),
+      Type::Num => write!(f, "num"),
+      Type::Adt(nam) => write!(f, "{nam}"),
+      Type::None => unreachable!(),
+    }
+  }
+}
 struct DisplayFn<F: Fn(&mut fmt::Formatter) -> fmt::Result>(F);
 
 impl<F: Fn(&mut fmt::Formatter) -> fmt::Result> Display for DisplayFn<F> {

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -173,6 +173,7 @@ pub enum Op {
 /// Pattern types.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Type {
+  None,
   Any,
   Tup,
   Num,
@@ -589,6 +590,7 @@ impl Definition {
 
   pub fn assert_no_pattern_matching_rules(&self) {
     assert!(self.rules.len() == 1, "Definition rules should have been removed in earlier pass");
+    assert!(self.rules[0].pats.is_empty(), "Definition args should have been removed in an earlier pass");
   }
 }
 

--- a/src/term/transform/desugar_match_expressions.rs
+++ b/src/term/transform/desugar_match_expressions.rs
@@ -6,19 +6,28 @@ use itertools::Itertools;
 use std::collections::{BTreeMap, HashMap, HashSet};
 
 impl Book {
-  /// Extracts any match terms into pattern matching functions.
+  /// Extracts adt match terms into pattern matching functions.
   /// Creates rules with potentially nested patterns, so the flattening pass needs to be called after.
-  pub fn extract_matches(&mut self) -> Result<(), String> {
+  pub fn extract_adt_matches(&mut self) -> Result<(), String> {
     let book = &mut MatchesBook::new(&mut self.def_names);
-
     for (def_id, def) in &mut self.defs {
       let def_name = book.def_names.name(def_id).cloned().unwrap();
       for rule in def.rules.iter_mut() {
-        rule.body.extract_matches(&def_name, &self.ctrs, book, &mut 0).map_err(|err| err.to_string())?;
+        rule.body.extract_adt_matches(&def_name, &self.ctrs, book, &mut 0).map_err(|err| err.to_string())?;
       }
     }
-
     self.defs.append(&mut book.new_defs);
+    Ok(())
+  }
+
+  /// Converts tuple and var matches into let expressions,
+  /// makes num matches have exactly one rule for zero and one rule for succ.
+  /// Should be run after pattern matching functions are desugared.
+  pub fn normalize_native_matches(&mut self) -> Result<(), String> {
+    for def in self.defs.values_mut() {
+      def.assert_no_pattern_matching_rules();
+      def.rules[0].body.normalize_native_matches(&self.ctrs).map_err(|e| e.to_string())?;
+    }
     Ok(())
   }
 }
@@ -74,8 +83,10 @@ impl std::fmt::Display for MatchError {
   }
 }
 
+//== ADT match to pattern matching function ==//
+
 impl Term {
-  fn extract_matches(
+  fn extract_adt_matches(
     &mut self,
     def_name: &Name,
     ctrs: &HashMap<Name, Name>,
@@ -83,39 +94,17 @@ impl Term {
     match_count: &mut usize,
   ) -> Result<(), MatchError> {
     match self {
-      Term::Match { scrutinee: box Term::Var { nam }, arms } => {
-        if arms.is_empty() {
-          return Err(MatchError::Empty);
-        }
-
+      Term::Match { scrutinee: box Term::Var { .. }, arms } => {
         for (_, term) in arms.iter_mut() {
-          term.extract_matches(def_name, ctrs, book, match_count)?;
+          term.extract_adt_matches(def_name, ctrs, book, match_count)?;
         }
-
         let matched_type = infer_match_type(arms.iter().map(|(x, _)| x), ctrs)?;
         match matched_type {
-          // This match is useless, will always go with the first rule.
-          // TODO: Throw a warning in this case
-          Type::Any => {
-            // Inside the match we renamed the variable, so we need to restore the name before the match to remove it.
-            let fst_arm = &mut arms[0];
-            let Pattern::Var(var) = &fst_arm.0 else { unreachable!() };
-            let body = &mut fst_arm.1;
-            if let Some(var) = var {
-              body.subst(var, &Term::Var { nam: nam.clone() });
-            }
-            *self = std::mem::take(body);
-          }
-          // Matching on nums is a primitive operation, we can leave it as is.
-          // Not extracting into a separate definition allows us to create very specific inets with the MATCH node.
-          Type::Num => {
-            let match_term = linearize_match_free_vars(self);
-            normalize_num_match(match_term)?
-          }
-          // TODO: It would be nice to also not extract tuple matches,
-          // but if they have nested patterns it gets more complicated.
-          // For now, we use `let (a, b) = x` to get the specific desired inet.
-          _ => {
+          // Don't extract non-adt matches.
+          Type::None | Type::Any | Type::Num => (),
+          // TODO: Instead of extracting tuple matches, we should flatten one layer and check sub-patterns for something to extract.
+          // For now, to prevent extraction we can use `let (a, b) = ...;`
+          Type::Adt(_) | Type::Tup => {
             *match_count += 1;
             let match_term = linearize_match_free_vars(self);
             let Term::Match { scrutinee: box Term::Var { nam }, arms } = match_term else { unreachable!() };
@@ -127,7 +116,7 @@ impl Term {
       }
 
       Term::Lam { bod, .. } | Term::Chn { bod, .. } => {
-        bod.extract_matches(def_name, ctrs, book, match_count)?;
+        bod.extract_adt_matches(def_name, ctrs, book, match_count)?;
       }
       Term::App { fun: fst, arg: snd, .. }
       | Term::Let { pat: Pattern::Var(_), val: fst, nxt: snd }
@@ -135,8 +124,8 @@ impl Term {
       | Term::Tup { fst, snd }
       | Term::Sup { fst, snd, .. }
       | Term::Opx { fst, snd, .. } => {
-        fst.extract_matches(def_name, ctrs, book, match_count)?;
-        snd.extract_matches(def_name, ctrs, book, match_count)?;
+        fst.extract_adt_matches(def_name, ctrs, book, match_count)?;
+        snd.extract_adt_matches(def_name, ctrs, book, match_count)?;
       }
       Term::Var { .. }
       | Term::Lnk { .. }
@@ -153,49 +142,6 @@ impl Term {
     }
 
     Ok(())
-  }
-}
-
-/// Converts free vars inside the match arms into lambdas with applications to give them the external value.
-/// Makes the rules extractable and linear (no need for dups when variable used in both rules)
-// TODO: Deal with unscoped lambdas/vars.
-fn linearize_match_free_vars(match_term: &mut Term) -> &mut Term {
-  let Term::Match { scrutinee: _, arms } = match_term else { unreachable!() };
-  // Collect the vars
-  let free_vars: IndexSet<Name> = arms
-    .iter()
-    .flat_map(|(pat, term)| term.free_vars().into_keys().filter(|k| !pat.names().contains(k)))
-    .collect();
-
-  // Add lambdas to the arms
-  for (_, body) in arms {
-    let old_body = std::mem::take(body);
-    let new_body = free_vars.iter().rev().fold(old_body, |body, var| Term::Lam {
-      tag: Tag::Static,
-      nam: Some(var.clone()),
-      bod: Box::new(body),
-    });
-    *body = new_body;
-  }
-
-  // Add apps to the match
-  let old_match = std::mem::take(match_term);
-  *match_term = free_vars.into_iter().fold(old_match, |acc, nam| Term::App {
-    tag: Tag::Static,
-    fun: Box::new(acc),
-    arg: Box::new(Term::Var { nam }),
-  });
-
-  // Get a reference to the match again
-  // It returns a reference and not an owned value because we want
-  //  to keep the new surrounding Apps but still modify the match further.
-  let mut match_term = match_term;
-  loop {
-    match match_term {
-      Term::App { tag: _, fun, arg: _ } => match_term = fun.as_mut(),
-      Term::Match { .. } => return match_term,
-      _ => unreachable!(),
-    }
   }
 }
 
@@ -226,31 +172,67 @@ fn make_def_name(def_name: &Name, ctr: &Name, i: usize) -> Name {
   Name(format!("{def_name}${ctr}${i}"))
 }
 
-/// Finds the expected type of the matched argument.
-/// Errors on incompatible types.
-/// Short-circuits if the first pattern is Type::Any.
-fn infer_match_type<'a>(
-  pats: impl Iterator<Item = &'a Pattern>,
-  ctrs: &HashMap<Name, Name>,
-) -> Result<Type, MatchError> {
-  let mut match_type = None;
-  for pat in pats {
-    let new_type = pat.to_type(ctrs).map_err(MatchError::Infer)?;
-    match (new_type, &mut match_type) {
-      (new, None) => match_type = Some(new),
-      // TODO: Should we throw a type inference error in this case?
-      // Since anything else will be sort of the wrong type (expected Var).
-      (_, Some(Type::Any)) => (),
-      (Type::Any, Some(_)) => (),
-      (Type::Tup, Some(Type::Tup)) => (),
-      (Type::Num, Some(Type::Num)) => (),
-      (Type::Adt(nam_new), Some(Type::Adt(nam_old))) if &nam_new == nam_old => (),
-      (new, Some(old)) => {
-        return Err(MatchError::Infer(format!("Type mismatch. Found '{}' expected {}.", new, old)));
+//== Native match normalization ==//
+
+impl Term {
+  fn normalize_native_matches(&mut self, ctrs: &HashMap<Name, Name>) -> Result<(), MatchError> {
+    match self {
+      Term::Match { scrutinee: box Term::Var { nam }, arms } => {
+        for (_, body) in arms.iter_mut() {
+          body.normalize_native_matches(ctrs)?;
+        }
+
+        let matched_type = infer_match_type(arms.iter().map(|(x, _)| x), ctrs)?;
+        match matched_type {
+          Type::None => {
+            return Err(MatchError::Empty);
+          }
+          // This match is useless, will always go with the first rule.
+          // TODO: Throw a warning in this case
+          Type::Any => {
+            // Inside the match we renamed the variable, so we need to restore the name before the match to remove it.
+            let fst_arm = &mut arms[0];
+            let Pattern::Var(var) = &fst_arm.0 else { unreachable!() };
+            let body = &mut fst_arm.1;
+            if let Some(var) = var {
+              body.subst(var, &Term::Var { nam: nam.clone() });
+            }
+            *self = std::mem::take(body);
+          }
+          // TODO: Don't extract tup matches earlier, only flatten earlier and then deal with them here.
+          Type::Tup => unreachable!(),
+          // Matching on nums is a primitive operation, we can leave it as is.
+          // Not extracting into a separate definition allows us to create very specific inets with the MATCH node.
+          Type::Num => {
+            let match_term = linearize_match_free_vars(self);
+            normalize_num_match(match_term)?
+          }
+          Type::Adt(_) => unreachable!("Adt match expressions should have been removed earlier"),
+        }
       }
-    };
+      Term::Match { .. } => unreachable!("Scrutinee of match expression should have been extracted already"),
+      Term::Let { val: fst, nxt: snd, .. }
+      | Term::App { fun: fst, arg: snd, .. }
+      | Term::Tup { fst, snd }
+      | Term::Dup { val: fst, nxt: snd, .. }
+      | Term::Sup { fst, snd, .. }
+      | Term::Opx { fst, snd, .. } => {
+        fst.normalize_native_matches(ctrs)?;
+        snd.normalize_native_matches(ctrs)?;
+      }
+      Term::Lam { bod, .. } | Term::Chn { bod, .. } => {
+        bod.normalize_native_matches(ctrs)?;
+      }
+      Term::Var { .. }
+      | Term::Lnk { .. }
+      | Term::Num { .. }
+      | Term::Str { .. }
+      | Term::Ref { .. }
+      | Term::Era => (),
+      Term::List { .. } => unreachable!(),
+    }
+    Ok(())
   }
-  Ok(match_type.unwrap())
 }
 
 /// Transforms a match on Num with any possible patterns into 'match x {0: ...; +: @x-1 ...}'.
@@ -332,4 +314,76 @@ fn normalize_num_match(term: &mut Term) -> Result<(), MatchError> {
   };
   *arms = vec![zero_arm, succ_arm];
   Ok(())
+}
+
+//== Common ==//
+
+/// Finds the expected type of the matched argument.
+/// Errors on incompatible types.
+/// Short-circuits if the first pattern is Type::Any.
+fn infer_match_type<'a>(
+  pats: impl Iterator<Item = &'a Pattern>,
+  ctrs: &HashMap<Name, Name>,
+) -> Result<Type, MatchError> {
+  let mut match_type = Type::None;
+  for pat in pats {
+    let new_type = pat.to_type(ctrs).map_err(MatchError::Infer)?;
+    match (new_type, &mut match_type) {
+      (new, Type::None) => match_type = new,
+      // TODO: Should we throw a type inference error in this case?
+      // Since anything else will be sort of the wrong type (expected Var).
+      (_, Type::Any) => (),
+      (Type::Any, _) => (),
+      (Type::Tup, Type::Tup) => (),
+      (Type::Num, Type::Num) => (),
+      (Type::Adt(nam_new), Type::Adt(nam_old)) if &nam_new == nam_old => (),
+      (new, old) => {
+        return Err(MatchError::Infer(format!("Type mismatch. Found '{}' expected {}.", new, old)));
+      }
+    };
+  }
+  Ok(match_type)
+}
+
+/// Converts free vars inside the match arms into lambdas with applications to give them the external value.
+/// Makes the rules extractable and linear (no need for dups when variable used in both rules)
+// TODO: Deal with unscoped lambdas/vars.
+fn linearize_match_free_vars(match_term: &mut Term) -> &mut Term {
+  let Term::Match { scrutinee: _, arms } = match_term else { unreachable!() };
+  // Collect the vars
+  let free_vars: IndexSet<Name> = arms
+    .iter()
+    .flat_map(|(pat, term)| term.free_vars().into_keys().filter(|k| !pat.names().contains(k)))
+    .collect();
+
+  // Add lambdas to the arms
+  for (_, body) in arms {
+    let old_body = std::mem::take(body);
+    let new_body = free_vars.iter().rev().fold(old_body, |body, var| Term::Lam {
+      tag: Tag::Static,
+      nam: Some(var.clone()),
+      bod: Box::new(body),
+    });
+    *body = new_body;
+  }
+
+  // Add apps to the match
+  let old_match = std::mem::take(match_term);
+  *match_term = free_vars.into_iter().fold(old_match, |acc, nam| Term::App {
+    tag: Tag::Static,
+    fun: Box::new(acc),
+    arg: Box::new(Term::Var { nam }),
+  });
+
+  // Get a reference to the match again
+  // It returns a reference and not an owned value because we want
+  //  to keep the new surrounding Apps but still modify the match further.
+  let mut match_term = match_term;
+  loop {
+    match match_term {
+      Term::App { tag: _, fun, arg: _ } => match_term = fun.as_mut(),
+      Term::Match { .. } => return match_term,
+      _ => unreachable!(),
+    }
+  }
 }

--- a/tests/golden_tests.rs
+++ b/tests/golden_tests.rs
@@ -148,7 +148,7 @@ fn flatten_rules() {
     book.desugar_let_destructors();
     book.desugar_implicit_match_binds();
     book.check_unbound_pats()?;
-    book.extract_matches()?;
+    book.extract_adt_matches()?;
     book.flatten_rules();
     Ok(book.to_string())
   })

--- a/tests/snapshots/encode_pattern_match__var_only.hvm.snap
+++ b/tests/snapshots/encode_pattern_match__var_only.hvm.snap
@@ -4,7 +4,7 @@ input_file: tests/golden_tests/encode_pattern_match/var_only.hvm
 ---
 (Foo) = λa λb λf (f a)
 
-(main) = λx Foo
+(main) = λx match x { false: Foo; true: False }
 
 (False) = #Bool λFalse #Bool λTrue False
 


### PR DESCRIPTION
This will be used for the next PR where I'll finally fix unscoped vars in adt matches