### PR TITLE
[sc-485] Error printing not correctly breaking lines

### DIFF
--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -69,7 +69,7 @@ impl Info {
 
   pub fn display(&self, verbose: bool) -> impl Display + '_ {
     DisplayFn(move |f| {
-      write!(f, "{}", self.errs.iter().map(|err| err.display(verbose)).join("\n"))?;
+      writeln!(f, "{}", self.errs.iter().map(|err| err.display(verbose)).join("\n"))?;
 
       for (def_name, errs) in &self.errs_with_def {
         writeln!(f, "In definition '{def_name}':")?;

--- a/src/term/check/shared_names.rs
+++ b/src/term/check/shared_names.rs
@@ -1,4 +1,6 @@
-use std::{collections::HashMap, fmt::Display};
+use std::fmt::Display;
+
+use indexmap::IndexMap;
 
 use crate::term::{Ctx, Name};
 
@@ -14,7 +16,7 @@ impl Display for TopLevelErr {
 impl Ctx<'_> {
   /// Checks if exists shared names from definitions, adts and constructors.
   pub fn check_shared_names(&mut self) {
-    let mut checked = HashMap::<&Name, usize>::new();
+    let mut checked = IndexMap::<&Name, usize>::new();
 
     for adt_name in self.book.adts.keys() {
       *checked.entry(adt_name).or_default() += 1;

--- a/src/term/mod.rs
+++ b/src/term/mod.rs
@@ -154,10 +154,10 @@ impl Clone for Term {
         Self::Dup { tag: tag.clone(), fst: fst.clone(), snd: snd.clone(), val: val.clone(), nxt: nxt.clone() }
       }
       Self::Sup { tag, fst, snd } => Self::Sup { tag: tag.clone(), fst: fst.clone(), snd: snd.clone() },
-      Self::Num { val } => Self::Num { val: val.clone() },
+      Self::Num { val } => Self::Num { val: *val },
       Self::Str { val } => Self::Str { val: val.clone() },
       Self::Lst { els } => Self::Lst { els: els.clone() },
-      Self::Opx { op, fst, snd } => Self::Opx { op: op.clone(), fst: fst.clone(), snd: snd.clone() },
+      Self::Opx { op, fst, snd } => Self::Opx { op: *op, fst: fst.clone(), snd: snd.clone() },
       Self::Mat { args, rules } => Self::Mat { args: args.clone(), rules: rules.clone() },
       Self::Ref { nam } => Self::Ref { nam: nam.clone() },
       Self::Era => Self::Era,

--- a/src/term/transform/resolve_refs.rs
+++ b/src/term/transform/resolve_refs.rs
@@ -124,7 +124,6 @@ impl Term {
         }
         Term::Lst { .. } => unreachable!("Should have been desugared already"),
         Term::Lnk { .. } | Term::Ref { .. } | Term::Num { .. } | Term::Str { .. } | Term::Era | Term::Err => {
-          ()
         }
       }
       Ok(())

--- a/tests/golden_tests/compile_file/error_messages.hvm
+++ b/tests/golden_tests/compile_file/error_messages.hvm
@@ -1,0 +1,9 @@
+data A = (A)
+data B = (B)
+
+Foo (C) = *
+Foo (D) = *
+
+Foo2 (E) = *
+
+Main = *

--- a/tests/snapshots/compile_file__error_messages.hvm.snap
+++ b/tests/snapshots/compile_file__error_messages.hvm.snap
@@ -1,0 +1,11 @@
+---
+source: tests/golden_tests.rs
+input_file: tests/golden_tests/compile_file/error_messages.hvm
+---
+Duplicated top-level name 'A'.
+Duplicated top-level name 'B'.
+In definition 'Foo':
+  Unbound constructor 'C'.
+  Unbound constructor 'D'.
+In definition 'Foo2':
+  Unbound constructor 'E'.


### PR DESCRIPTION
Because `join` method does not insert a newline at the end