### PR TITLE
[sc-654] Fix linearize binds before match

### DIFF
--- a/tests/golden_tests/simplify_matches/complex_with_case.hvm
+++ b/tests/golden_tests/simplify_matches/complex_with_case.hvm
@@ -1,0 +1,11 @@
+data Tree = (Node lt rt rd ld) | (Leaf val)
+
+(map) =
+  λarg1 λarg2 use tree = arg2;
+  use f = arg1;
+  match tree with f { 
+    Node: (Node (map f tree.lt) (map f tree.rt) (map f tree.rd) (map f tree.ld)); 
+    Leaf: (Leaf (f tree.val)); 
+  }
+
+main = map

--- a/tests/snapshots/simplify_matches__complex_with_case.hvm.snap
+++ b/tests/snapshots/simplify_matches__complex_with_case.hvm.snap
@@ -1,0 +1,11 @@
+---
+source: tests/golden_tests.rs
+input_file: tests/golden_tests/simplify_matches/complex_with_case.hvm
+---
+(map) = λa λb (match b { Node c d e f: λg (Node (map g c) (map g d) (map g e) (map g f)); Leaf h: λi (Leaf (i h)); } a)
+
+(main) = map
+
+(Node) = λa λb λc λd λe λf (e a b c d)
+
+(Leaf) = λa λb λc (c a)


### PR DESCRIPTION
Was linearizing incorrectly when a `let` or `use` depended on a lambda variable that is not used by the match, but not linearized because it comes before a lambda variable that IS used by the match.